### PR TITLE
VP-4045 Fix: recalucate aggregation after products loaded

### DIFF
--- a/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/Aggregates/CartAggregateTests.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/Aggregates/CartAggregateTests.cs
@@ -30,7 +30,9 @@ namespace VirtoCommerce.XPurchase.Tests.Aggregates
             var store = GetStore();
             var currency = GetCurrency();
 
-            aggregate.GrabCartAsync(cart, store, member, currency).GetAwaiter().GetResult();
+            aggregate.GrabCart(cart, store, member, currency);
+
+            aggregate.RecalculateAsync().GetAwaiter().GetResult();
         }
 
         #region UpdateCartComment

--- a/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/Helpers/XPurchaseMoqHelper.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/Helpers/XPurchaseMoqHelper.cs
@@ -1,12 +1,8 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using AutoFixture;
 using AutoMapper;
 using Bogus;
-using Microsoft.AspNetCore.Identity;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Moq;
 using VirtoCommerce.CartModule.Core.Model;
 using VirtoCommerce.CartModule.Core.Services;
@@ -181,7 +177,7 @@ namespace VirtoCommerce.XPurchase.Tests.Helpers
                 _taxProviderSearchServiceMock.Object,
                 _mapperMock.Object);
 
-            aggregate.GrabCartAsync(cart, new Store(), GetMember(), GetCurrency()).GetAwaiter().GetResult();
+            aggregate.GrabCart(cart, new Store(), GetMember(), GetCurrency());
 
             return aggregate;
         }
@@ -189,7 +185,7 @@ namespace VirtoCommerce.XPurchase.Tests.Helpers
 
     public class MockedPromotionResult : PromotionResult
     {
-        public new ICollection<PromotionReward> Rewards { get => Enumerable.Empty<PromotionReward>().ToList(); }
+        public new ICollection<PromotionReward> Rewards => Enumerable.Empty<PromotionReward>().ToList();
     }
 
     public class MockedMember : Member

--- a/src/XPurchase/VirtoCommerce.XPurchase/CartAggregate.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/CartAggregate.cs
@@ -92,7 +92,7 @@ namespace VirtoCommerce.XPurchase
         public bool IsValid => !ValidationErrors.Any();
         public IList<ValidationFailure> ValidationErrors { get; protected set; } = new List<ValidationFailure>();
 
-        public virtual async Task<CartAggregate> GrabCartAsync(ShoppingCart cart, Store store, Member member, Currency currency)
+        public virtual CartAggregate GrabCart(ShoppingCart cart, Store store, Member member, Currency currency)
         {
             Id = cart.Id;
             Cart = cart;
@@ -102,8 +102,6 @@ namespace VirtoCommerce.XPurchase
             Cart.IsAnonymous = member == null;
             //TODO: Need to check what member.Name contains name for all derived member types such as contact etc.
             Cart.CustomerName = member?.Name ?? "Anonymous";
-
-            await RecalculateAsync();
 
             return this;
         }

--- a/src/XPurchase/VirtoCommerce.XPurchase/CartAggregateRepository.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/CartAggregateRepository.cs
@@ -175,7 +175,9 @@ namespace VirtoCommerce.XPurchase
 
             var member = await GetCustomerAsync(cart.CustomerId);
             var aggregate = _cartAggregateFactory();
-            await aggregate.GrabCartAsync(cart, store, member, currency);
+
+            aggregate.GrabCart(cart, store, member, currency);
+
             var validationContext = await _cartValidationContextFactory.CreateValidationContextAsync(aggregate);
             //Populate aggregate.CartProducts with the  products data for all cart  line items
             foreach (var cartProduct in validationContext.AllCartProducts)

--- a/src/XPurchase/VirtoCommerce.XPurchase/CartAggregateRepository.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/CartAggregateRepository.cs
@@ -132,7 +132,7 @@ namespace VirtoCommerce.XPurchase
             var searchResult = await _shoppingCartSearchService.SearchCartAsync(criteria);
             var cartAggregates = await GetCartsForShoppingCartsAsync(searchResult.Results);
 
-            return new SearchCartResponse() { Results = cartAggregates, TotalCount = searchResult.TotalCount};
+            return new SearchCartResponse() { Results = cartAggregates, TotalCount = searchResult.TotalCount };
         }
 
         public virtual async Task RemoveCartAsync(string cartId) => await _shoppingCartService.DeleteAsync(new[] { cartId });
@@ -182,6 +182,9 @@ namespace VirtoCommerce.XPurchase
             {
                 aggregate.CartProducts[cartProduct.Id] = cartProduct;
             }
+
+            await aggregate.RecalculateAsync();
+
             //Run validation
             await aggregate.ValidateAsync(validationContext);
 
@@ -217,6 +220,5 @@ namespace VirtoCommerce.XPurchase
 
             return result;
         }
-
     }
 }

--- a/src/XPurchase/VirtoCommerce.XPurchase/ICartAggregateRepository.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/ICartAggregateRepository.cs
@@ -15,7 +15,7 @@ namespace VirtoCommerce.XPurchase
 
         Task<CartAggregate> GetCartAsync(string cartName, string storeId, string userId, string cultureName, string currencyCode, string type = null);
 
-        Task<CartAggregate> GetCartByIdAsync(string cartId, string cultureName = null);
+        Task<CartAggregate> GetCartByIdAsync(string cartId, string language = null);
 
         Task<CartAggregate> GetCartForShoppingCartAsync(ShoppingCart cart, string cultureName = null);
 


### PR DESCRIPTION
https://virtocommerce.atlassian.net/browse/VP-4045

### Problem
A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

### Solution
A clear and concise description of what you want to happen.

### Proposed of changes
Describe the technical details of realization provided by you.

### Additional context (optional)
Add any other context or screenshots about the feature request here.

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
