### PR TITLE
VP-3968: Fix error when user add more products than contains in stock

### DIFF
--- a/src/XPurchase/VirtoCommerce.XPurchase/CartAggregate.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/CartAggregate.cs
@@ -124,7 +124,11 @@ namespace VirtoCommerce.XPurchase
                 throw new ArgumentNullException(nameof(newCartItem));
             }
 
-            await new NewCartItemValidator().ValidateAndThrowAsync(newCartItem, ruleSet: ValidationRuleSet);
+            var validationResult = await new NewCartItemValidator().ValidateAsync(newCartItem, ruleSet: ValidationRuleSet);
+            if (!validationResult.IsValid)
+            {
+                ValidationErrors.AddRange(validationResult.Errors);
+            }
 
             var lineItem = _mapper.Map<LineItem>(newCartItem.CartProduct);
             lineItem.Quantity = newCartItem.Quantity;
@@ -175,7 +179,11 @@ namespace VirtoCommerce.XPurchase
         {
             EnsureCartExists();
 
-            await new ItemQtyAdjustmentValidator(this).ValidateAndThrowAsync(qtyAdjustment, ruleSet: ValidationRuleSet);
+            var validationResult = await new ItemQtyAdjustmentValidator(this).ValidateAsync(qtyAdjustment, ruleSet: ValidationRuleSet);
+            if (!validationResult.IsValid)
+            {
+                ValidationErrors.AddRange(validationResult.Errors);
+            }
 
             var lineItem = Cart.Items.First(i => i.Id == qtyAdjustment.LineItemId);
 

--- a/src/XPurchase/VirtoCommerce.XPurchase/CartErrorDescriber.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/CartErrorDescriber.cs
@@ -39,12 +39,12 @@ namespace VirtoCommerce.XPurchase
             return result;
         }
 
-        public static CartValidationError ProductQtyChangedError(IEntity entity, long newQty)
+        public static CartValidationError ProductQtyChangedError(IEntity entity, long availQty)
         {
             var result = new CartValidationError(entity, "The product available qty is changed", "PRODUCT_QTY_CHANGED");
             result.FormattedMessagePlaceholderValues = new Dictionary<string, object>
             {
-                ["new_qty"] = newQty
+                ["availQty"] = availQty
             };
             return result;
         }

--- a/src/XPurchase/VirtoCommerce.XPurchase/CartValidationError.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/CartValidationError.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
+using System.Linq;
 using FluentValidation.Results;
 using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.XPurchase.Schemas;
 
 namespace VirtoCommerce.XPurchase
 {
@@ -13,9 +15,11 @@ namespace VirtoCommerce.XPurchase
             ObjectId = entity.Id;
             ErrorMessage = error;
             ErrorCode = errorCode;
-            FormattedMessagePlaceholderValues = new Dictionary<string, object>();
         }
+
         public string ObjectType { get; set; }
         public string ObjectId { get; set; }
+        public List<ErrorParameter> ErrorParameters =>
+            FormattedMessagePlaceholderValues.Select(kvp => new ErrorParameter {Key = kvp.Key, Value = kvp.Value.ToString()}).ToList();
     }
 }

--- a/src/XPurchase/VirtoCommerce.XPurchase/Schemas/ErrorParameter.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Schemas/ErrorParameter.cs
@@ -1,0 +1,8 @@
+namespace VirtoCommerce.XPurchase.Schemas
+{
+    public class ErrorParameter
+    {
+        public string Key { get; set; }
+        public string Value { get; set; }
+    }
+}

--- a/src/XPurchase/VirtoCommerce.XPurchase/Schemas/ErrorParameterType.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Schemas/ErrorParameterType.cs
@@ -1,0 +1,13 @@
+using GraphQL.Types;
+
+namespace VirtoCommerce.XPurchase.Schemas
+{
+    public class ErrorParameterType : ObjectGraphType<ErrorParameter>
+    {
+        public ErrorParameterType()
+        {
+            Field(x=>x.Key).Description("key");
+            Field(x => x.Value).Description("Value");
+        }
+    }
+}

--- a/src/XPurchase/VirtoCommerce.XPurchase/Schemas/ValidationErrorType.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Schemas/ValidationErrorType.cs
@@ -9,7 +9,8 @@ namespace VirtoCommerce.XPurchase.Schemas
             Field(x => x.ErrorCode, nullable: true).Description("Error code");
             Field(x => x.ErrorMessage, nullable: true).Description("Error msg");
             Field(x => x.ObjectId, nullable: true).Description("Object id");
-            Field(x => x.ObjectType, nullable: true).Description("Object type");            
+            Field(x => x.ObjectType, nullable: true).Description("Object type");
+            Field<ListGraphType<ErrorParameterType>>(name: "errorParameters", resolve: x => x.Source.ErrorParameters);
         }
     }
 }


### PR DESCRIPTION
### Problem
Error when user add more products than contains in stock

### Solution
Do not throw error when item quantity invalid

### Proposed of changes
Describe the technical details of realization provided by you.

### Additional context (optional)
Add any other context or screenshots about the feature request here.

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
