### PR TITLE
VP-6197: Fix prices entry mapping

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Binding/PriceBinder.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Binding/PriceBinder.cs
@@ -36,14 +36,14 @@ namespace VirtoCommerce.XDigitalCatalog.Binding
 
                     foreach (var listPrice in pair.Value is Array ? (object[])pair.Value : new[] { pair.Value })
                     {
-                        var list = Convert.ToDecimal(listPrice);
-                        if (list == default) continue;
+                        // If schema field required without filled values
+                        if (listPrice is null) continue;
 
                         var price = new Price
                         {
                             Currency = match.Groups[1].Value.ToUpperInvariant(),
                             PricelistId = match.Groups[2].Value,
-                            List = list
+                            List = Convert.ToDecimal(listPrice)
                         };
 
                         result.Add(price);

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Binding/PriceBinder.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Binding/PriceBinder.cs
@@ -32,18 +32,21 @@ namespace VirtoCommerce.XDigitalCatalog.Binding
                 foreach (var pair in searchDocument)
                 {
                     var match = _priceFieldRegExp.Match(pair.Key);
-                    if (match.Success)
+                    if (!match.Success) continue;
+
+                    foreach (var listPrice in pair.Value is Array ? (object[])pair.Value : new[] { pair.Value })
                     {
-                        foreach (var listPrice in pair.Value is Array ? (object[])pair.Value : new[] { pair.Value })
+                        var list = Convert.ToDecimal(listPrice);
+                        if (list == default) continue;
+
+                        var price = new Price
                         {
-                            var price = new Price
-                            {
-                                Currency = match.Groups[1].Value,
-                                PricelistId = match.Groups[2].Value,
-                                List = Convert.ToDecimal(listPrice)
-                            };
-                            result.Add(price);
-                        }
+                            Currency = match.Groups[1].Value.ToUpperInvariant(),
+                            PricelistId = match.Groups[2].Value,
+                            List = list
+                        };
+
+                        result.Add(price);
                     }
                 }
             }

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Mapping/ProductMappingProfile.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Mapping/ProductMappingProfile.cs
@@ -129,13 +129,7 @@ namespace VirtoCommerce.XDigitalCatalog.Mapping
                     result.Add(nominalPrice);
                 }
 
-                if (!context.Items.TryGetValue("currency", out var currentCurrency) && !(currentCurrency is string))
-                {
-                    return result;
-                }
-
-                // Filter by current currency
-                return result.Where(x => (x.Currency == null) || x.Currency.Equals(currentCurrency)).ToList();
+                return result;
             });
         }
     }


### PR DESCRIPTION
### Problem:
1. Pricing evaluation is not enough because of all calculations based on the current prices;
2. Binding was incorrect.

### Solution
1. Move past the logic of getting prices from Indexed Prices;
2. Fix binder to not creating prices with 0 (zero) cost.

### Jira:
https://virtocommerce.atlassian.net/browse/VP-6197