### PR TITLE
VP-6103: Fix changeLineItemPrise mutation

### DIFF
--- a/src/XPurchase/VirtoCommerce.XPurchase/CartAggregate.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/CartAggregate.cs
@@ -166,7 +166,7 @@ namespace VirtoCommerce.XPurchase
         {
             EnsureCartExists();
 
-            var lineItem = Cart.Items.FirstOrDefault(x => x.ProductId == priceAdjustment.LineItemId);
+            var lineItem = Cart.Items.FirstOrDefault(x => x.Id == priceAdjustment.LineItemId);
             if (lineItem != null)
             {
                 await new ChangeCartItemPriceValidator(this).ValidateAndThrowAsync(priceAdjustment, ruleSet: ValidationRuleSet);

--- a/src/XPurchase/VirtoCommerce.XPurchase/CartAggregate.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/CartAggregate.cs
@@ -166,7 +166,7 @@ namespace VirtoCommerce.XPurchase
         {
             EnsureCartExists();
 
-            var lineItem = Cart.Items.FirstOrDefault(x => x.Id == priceAdjustment.LineItemId);
+            var lineItem = Cart.Items.FirstOrDefault(x => x.ProductId == priceAdjustment.LineItemId);
             if (lineItem != null)
             {
                 await new ChangeCartItemPriceValidator(this).ValidateAndThrowAsync(priceAdjustment, ruleSet: ValidationRuleSet);

--- a/src/XPurchase/VirtoCommerce.XPurchase/Commands/ChangeCartItemPriceCommand.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Commands/ChangeCartItemPriceCommand.cs
@@ -1,4 +1,4 @@
-﻿namespace VirtoCommerce.XPurchase.Commands
+namespace VirtoCommerce.XPurchase.Commands
 {
     public class ChangeCartItemPriceCommand : CartCommand
     {
@@ -6,14 +6,14 @@
         {
         }
 
-        public ChangeCartItemPriceCommand(string storeId, string cartType, string cartName, string userId, string currency, string lang, string productId, decimal price)
+        public ChangeCartItemPriceCommand(string storeId, string cartType, string cartName, string userId, string currency, string lang, string lineItemId, decimal price)
             : base(storeId, cartType, cartName, userId, currency, lang)
         {
-            ProductId = productId;
+            LineItemId = lineItemId;
             Price = price;
         }
 
-        public string ProductId { get; set; }
+        public string LineItemId { get; set; }
 
         /// <summary>
         /// Manual price

--- a/src/XPurchase/VirtoCommerce.XPurchase/Commands/ChangeCartItemPriceCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Commands/ChangeCartItemPriceCommandHandler.cs
@@ -13,7 +13,7 @@ namespace VirtoCommerce.XPurchase.Commands
         public override async Task<CartAggregate> Handle(ChangeCartItemPriceCommand request, CancellationToken cancellationToken)
         {
             var cartAggregate = await GetOrCreateCartFromCommandAsync(request);
-            await cartAggregate.ChangeItemPriceAsync(new PriceAdjustment(request.ProductId, request.Price));
+            await cartAggregate.ChangeItemPriceAsync(new PriceAdjustment(request.LineItemId, request.Price));
 
             return await SaveCartAsync(cartAggregate);
         }

--- a/src/XPurchase/VirtoCommerce.XPurchase/Schemas/InputChangeCartItemPriceType.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Schemas/InputChangeCartItemPriceType.cs
@@ -6,7 +6,7 @@ namespace VirtoCommerce.XPurchase.Schemas
     {
         public InputChangeCartItemPriceType()
         {
-            Field<NonNullGraphType<StringGraphType>>("productId");
+            Field<NonNullGraphType<StringGraphType>>("lineItemId");
             Field<NonNullGraphType<DecimalGraphType>>("price");
         }
     }

--- a/src/XPurchase/VirtoCommerce.XPurchase/Schemas/PurchaseSchema.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Schemas/PurchaseSchema.cs
@@ -194,7 +194,7 @@ namespace VirtoCommerce.XPurchase.Schemas
             ///          "language": "en-US",
             ///          "currency": "USD",
             ///          "cartType": "cart",
-            ///          "productId": "9cbd8f316e254a679ba34a900fccb076",
+            ///          "lineItemId": "9cbd8f316e254a679ba34a900fccb076",
             ///          "price": 777
             ///      }
             ///   }


### PR DESCRIPTION
### Related task:     
VP-6103 Create example queries for QA team
### Problem:
changeCartItemPrice. the field named as productId. When productId from platform set then nothing happens. When lineItemId set to productId from cart then price changed
### Solution:
Fix behaviour related to storefront
### Changes:
Linq query updated 


