### PR TITLE
VP-6005: Enrich category outlines with related catalog/category names

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Extensions/ServiceCollectionExtensions.cs
@@ -32,7 +32,7 @@ namespace VirtoCommerce.XDigitalCatalog.Extensions
             services.AddPipeline<SearchCategoryResponse>(builder =>
             {
                 builder.AddMiddleware(typeof(EnsureCategoryLoadedMiddleware));
-                builder.AddMiddleware(typeof(EnsureCategoryOutlinesMiddleware));
+                builder.AddMiddleware(typeof(EnsureCategoryOutlineNamesLoadedMiddleware));
             });
 
             services.AddAutoMapper(typeof(XDigitalCatalogAnchor));

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Extensions/ServiceCollectionExtensions.cs
@@ -32,6 +32,7 @@ namespace VirtoCommerce.XDigitalCatalog.Extensions
             services.AddPipeline<SearchCategoryResponse>(builder =>
             {
                 builder.AddMiddleware(typeof(EnsureCategoryLoadedMiddleware));
+                builder.AddMiddleware(typeof(EnsureCategoryOutlinesMiddleware));
             });
 
             services.AddAutoMapper(typeof(XDigitalCatalogAnchor));

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Middlewares/EnsureCategoryOutlineNamesLoadedMiddleware.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Middlewares/EnsureCategoryOutlineNamesLoadedMiddleware.cs
@@ -12,12 +12,12 @@ namespace VirtoCommerce.XDigitalCatalog.Middlewares
     /// This middleware enriches outlines with names.
     /// Just reads names of catalogs and categories in outlines thru ICatalogService, ICategoryService
     /// </summary>
-    class EnsureCategoryOutlinesMiddleware : IAsyncMiddleware<SearchCategoryResponse>
+    class EnsureCategoryOutlineNamesLoadedMiddleware : IAsyncMiddleware<SearchCategoryResponse>
     {
         private readonly ICatalogService _catalogService;
         private readonly ICategoryService _categoryService;
 
-        public EnsureCategoryOutlinesMiddleware(ICatalogService catalogService, ICategoryService categoryService)
+        public EnsureCategoryOutlineNamesLoadedMiddleware(ICatalogService catalogService, ICategoryService categoryService)
         {
             _catalogService = catalogService;
             _categoryService = categoryService;
@@ -35,12 +35,12 @@ namespace VirtoCommerce.XDigitalCatalog.Middlewares
 
                 foreach (var catalogOutlineItem in catalogOutlineItems)
                 {
-                    catalogOutlineItem.Name = catalogs[catalogOutlineItem.Id].Name;
+                    catalogOutlineItem.Name = catalogs.ContainsKey(catalogOutlineItem.Id) ? catalogs[catalogOutlineItem.Id].Name : null;
                 }
 
                 foreach (var categoryOutlineItem in categoryOutlineItems)
                 {
-                    categoryOutlineItem.Name = categories[categoryOutlineItem.Id].Name;
+                    categoryOutlineItem.Name = categories.ContainsKey(categoryOutlineItem.Id) ? categories[categoryOutlineItem.Id].Name : null;
                 }
             }
             await next(parameter);

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Middlewares/EnsureCategoryOutlineNamesLoadedMiddleware.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Middlewares/EnsureCategoryOutlineNamesLoadedMiddleware.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using PipelineNet.Middleware;
@@ -12,7 +13,7 @@ namespace VirtoCommerce.XDigitalCatalog.Middlewares
     /// This middleware enriches outlines with names.
     /// Just reads names of catalogs and categories in outlines thru ICatalogService, ICategoryService
     /// </summary>
-    class EnsureCategoryOutlineNamesLoadedMiddleware : IAsyncMiddleware<SearchCategoryResponse>
+    public class EnsureCategoryOutlineNamesLoadedMiddleware : IAsyncMiddleware<SearchCategoryResponse>
     {
         private readonly ICatalogService _catalogService;
         private readonly ICategoryService _categoryService;
@@ -35,12 +36,12 @@ namespace VirtoCommerce.XDigitalCatalog.Middlewares
 
                 foreach (var catalogOutlineItem in catalogOutlineItems)
                 {
-                    catalogOutlineItem.Name = catalogs.ContainsKey(catalogOutlineItem.Id) ? catalogs[catalogOutlineItem.Id].Name : null;
+                    catalogOutlineItem.Name = catalogs.GetValueOrDefault(catalogOutlineItem.Id)?.Name;
                 }
 
                 foreach (var categoryOutlineItem in categoryOutlineItems)
                 {
-                    categoryOutlineItem.Name = categories.ContainsKey(categoryOutlineItem.Id) ? categories[categoryOutlineItem.Id].Name : null;
+                    categoryOutlineItem.Name = categories.GetValueOrDefault(categoryOutlineItem.Id)?.Name;
                 }
             }
             await next(parameter);

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Middlewares/EnsureCategoryOutlinesMiddleware.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Middlewares/EnsureCategoryOutlinesMiddleware.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using PipelineNet.Middleware;
+using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.CatalogModule.Core.Services;
+using VirtoCommerce.XDigitalCatalog.Queries;
+
+namespace VirtoCommerce.XDigitalCatalog.Middlewares
+{
+    /// <summary>
+    /// This middleware enriches outlines with names.
+    /// Just reads names of catalogs and categories in outlines thru ICatalogService, ICategoryService
+    /// </summary>
+    class EnsureCategoryOutlinesMiddleware : IAsyncMiddleware<SearchCategoryResponse>
+    {
+        private readonly ICatalogService _catalogService;
+        private readonly ICategoryService _categoryService;
+
+        public EnsureCategoryOutlinesMiddleware(ICatalogService catalogService, ICategoryService categoryService)
+        {
+            _catalogService = catalogService;
+            _categoryService = categoryService;
+        }
+
+        public async Task Run(SearchCategoryResponse parameter, Func<SearchCategoryResponse, Task> next)
+        {
+            if (parameter.Query.IncludeFields.Contains("outlines.name"))
+            {
+                var outlineItems = parameter.Results.SelectMany(x => x.Category.Outlines).SelectMany(x => x.Items).Where(x => x.Name is null);
+                var catalogOutlineItems = outlineItems.Where(x => x.SeoObjectType == "Catalog");
+                var categoryOutlineItems = outlineItems.Where(x => x.SeoObjectType == "Category");
+                var catalogs = (await _catalogService.GetByIdsAsync(catalogOutlineItems.Select(x => x.Id).Distinct().ToArray(), CatalogResponseGroup.Info.ToString())).ToDictionary(x => x.Id);
+                var categories = (await _categoryService.GetByIdsAsync(categoryOutlineItems.Select(x => x.Id).Distinct().ToArray(), CategoryResponseGroup.Info.ToString())).ToDictionary(x => x.Id);
+
+                foreach (var catalogOutlineItem in catalogOutlineItems)
+                {
+                    catalogOutlineItem.Name = catalogs[catalogOutlineItem.Id].Name;
+                }
+
+                foreach (var categoryOutlineItem in categoryOutlineItems)
+                {
+                    categoryOutlineItem.Name = categories[categoryOutlineItem.Id].Name;
+                }
+            }
+            await next(parameter);
+        }
+    }
+}


### PR DESCRIPTION
The problem description:
if we have graphql request like this (example):
```
{
categories(storeId:"clothing")
  {

    items
    {
      code,
      name
      outline
      outlines
      {
      	items
        {
          id,
          name
	}
      }
    }
}
}
```
outlines items names are always returned as nulls.
This PR solves this problem by reading outline-related catalog/category names and setting to result.