### PR TITLE
VP-6425: Do not ignore currency in cart

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.Core/Models/ProductPrice.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Models/ProductPrice.cs
@@ -92,7 +92,7 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Models
         /// <returns></returns>
         public TierPrice GetTierPrice(int quantity)
         {
-            var retVal = TierPrices.OrderBy(x => x.Quantity).LastOrDefault(x => x.Quantity <= quantity);
+            var retVal = TierPrices.OrderBy(x => x.Quantity).LastOrDefault(x => x.Quantity <= quantity && x.Currency == Currency);
             if (retVal == null)
             {
                 retVal = new TierPrice(SalePrice, 1);
@@ -150,7 +150,6 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Models
             {
                 TierPrices.Apply(x => x.ApplyTaxRates(productTaxRates));
             }
-
         }
 
         #endregion ITaxable Members

--- a/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/Helpers/XPurchaseMoqHelper.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/Helpers/XPurchaseMoqHelper.cs
@@ -68,6 +68,8 @@ namespace VirtoCommerce.XPurchase.Tests.Helpers
 
                 var cartProduct = new CartProduct(catalogProduct);
 
+                var currency = GetCurrency();
+
                 cartProduct.ApplyPrices(new List<Price>()
                 {
                     new Price
@@ -76,8 +78,9 @@ namespace VirtoCommerce.XPurchase.Tests.Helpers
                         PricelistId = _fixture.Create<string>(),
                         List = ItemCost,
                         MinQuantity = 1,
+                        Currency = currency.Code
                     }
-                }, GetCurrency());
+                }, currency);
 
                 var store = GetStore();
 
@@ -110,7 +113,10 @@ namespace VirtoCommerce.XPurchase.Tests.Helpers
                                             .With(x => x.ListPrice, ItemCost)
                                             .Create());
 
-            _fixture.Register<Price>(() => null);
+            _fixture.Register(() => new Price
+            {
+                Currency = GetCurrency().Code
+            });
 
             _cartProductServiceMock = new Mock<ICartProductService>();
 

--- a/src/XPurchase/VirtoCommerce.XPurchase/CartProduct.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/CartProduct.cs
@@ -62,16 +62,20 @@ namespace VirtoCommerce.XPurchase
             AllPrices.Clear();
             Price = null;
 
+            // Return correct currency from price
+            Currency GetCurrencyFromPrice(PricingModule.Core.Model.Price price) => new Currency(new CoreModule.Core.Common.Language(currency.CultureName), price.Currency);
+
             AllPrices = prices.Where(x => x.ProductId == Id)
                               .Select(x =>
                               {
-                                  var productPrice = new ProductPrice(currency)
+                                  var productPrice = new ProductPrice(GetCurrencyFromPrice(x))
                                   {
                                       PricelistId = x.PricelistId,
-                                      ListPrice = new Money(x.List, currency),
+                                      ListPrice = new Money(x.List, GetCurrencyFromPrice(x)),
                                       MinQuantity = x.MinQuantity
                                   };
-                                  productPrice.SalePrice = x.Sale == null ? productPrice.ListPrice : new Money(x.Sale.GetValueOrDefault(), currency);
+
+                                  productPrice.SalePrice = !x.Sale.HasValue ? productPrice.ListPrice : new Money(x.Sale.Value, GetCurrencyFromPrice(x));
 
                                   return productPrice;
                               }).ToList();

--- a/src/XPurchase/VirtoCommerce.XPurchase/Commands/AddCartItemCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Commands/AddCartItemCommandHandler.cs
@@ -27,6 +27,12 @@ namespace VirtoCommerce.XPurchase.Commands
                 CartProduct = product
             });
 
+            // Prevent saving invalid cart
+            if (!cartAggregate.IsValid)
+            {
+                return cartAggregate;
+            }
+
             return await SaveCartAsync(cartAggregate);
         }
     }

--- a/src/XPurchase/VirtoCommerce.XPurchase/Commands/CartCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Commands/CartCommandHandler.cs
@@ -24,7 +24,7 @@ namespace VirtoCommerce.XPurchase.Commands
             CartAggregate result;
             if (!string.IsNullOrEmpty(request.CartId))
             {
-                result = await GetCartById(request.CartId, request.Language);
+                result = await GetCartById(request.CartId, request.Language, request.Currency);
             }
             else
             {
@@ -37,7 +37,7 @@ namespace VirtoCommerce.XPurchase.Commands
             return result;
         }
 
-        protected virtual async Task<CartAggregate> GetCartById(string cartId, string language) => await CartRepository.GetCartByIdAsync(cartId, language);
+        protected virtual async Task<CartAggregate> GetCartById(string cartId, string language, string currency) => await CartRepository.GetCartByIdAsync(cartId, language, currency);
 
         protected virtual Task<CartAggregate> CreateNewCartAggregateAsync(TCartCommand request)
         {

--- a/src/XPurchase/VirtoCommerce.XPurchase/Commands/MergeCartCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Commands/MergeCartCommandHandler.cs
@@ -13,7 +13,7 @@ namespace VirtoCommerce.XPurchase.Commands
         public override async Task<CartAggregate> Handle(MergeCartCommand request, CancellationToken cancellationToken)
         {
             var cartAggr = await GetOrCreateCartFromCommandAsync(request);
-            var secondCart = await GetCartById(request.SecondCartId, request.Language);
+            var secondCart = await GetCartById(request.SecondCartId, request.Language, request.Currency);
             if (secondCart != null)
             {
                 cartAggr = await cartAggr.MergeWithCartAsync(secondCart);

--- a/src/XPurchase/VirtoCommerce.XPurchase/ICartAggregateRepository.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/ICartAggregateRepository.cs
@@ -1,9 +1,6 @@
-using System.Collections;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using VirtoCommerce.CartModule.Core.Model;
 using VirtoCommerce.CartModule.Core.Model.Search;
-using VirtoCommerce.XPurchase.Commands;
 using VirtoCommerce.XPurchase.Queries;
 
 namespace VirtoCommerce.XPurchase
@@ -16,10 +13,10 @@ namespace VirtoCommerce.XPurchase
 
         Task<CartAggregate> GetCartAsync(string cartName, string storeId, string userId, string cultureName, string currencyCode, string type = null, string responseGroup = null);
 
-        Task<CartAggregate> GetCartByIdAsync(string cartId, string language = null);
+        Task<CartAggregate> GetCartByIdAsync(string cartId, string cultureName = null, string currencyCode = null);
 
         Task<CartAggregate> GetCartForShoppingCartAsync(ShoppingCart cart, string cultureName = null);
 
-        Task<SearchCartResponse> SearchCartAsync(ShoppingCartSearchCriteria  criteria);
+        Task<SearchCartResponse> SearchCartAsync(ShoppingCartSearchCriteria criteria);
     }
 }

--- a/src/XPurchase/VirtoCommerce.XPurchase/Queries/GetCartQueryHandler.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Queries/GetCartQueryHandler.cs
@@ -21,7 +21,6 @@ namespace VirtoCommerce.XPurchase.Queries
         public virtual Task<CartAggregate> Handle(GetCartByIdQuery request, CancellationToken cancellationToken)
         {
             return _cartAggrRepository.GetCartByIdAsync(request.CartId);
-
         }
     }
 }


### PR DESCRIPTION
### Problem:
1. After creating cart aggregate from the existed cart; aggregate start to ignore the `currency code` argument from any request;
2. TierPrices mashes anything but current currency;
3. `ApplyPrices` method picks the wrong currency code.
### Solution:
1. Pass the `currency code` argument to the `GetCartByIdAsync` method;
2. Add currency code picker to the `ApplyPrices` method.
### Jira:
https://virtocommerce.atlassian.net/browse/VP-6425