### PR TITLE
VP-6269: Use xapi module without elastic search module

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ Read this [article...](docs/getting-started.md)
 ## How to extend
 Read this [article...](docs/x-api-extensions.md)
 
+## Limitation
+
+The project has integration with Elastic Search 7.x and Azure Search Service providers for indexing search.
+
+Lucene search provider not supported.
 ## Documentation
 
 [Experience API Module Document](/docs/index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,3 +46,9 @@ Read this [article...](./getting-started.md)
 ## How to extend
 Read this [article...](./x-api-extensions.md)
 
+## Limitation
+
+The project has integration with Elastic Search 7.x and Azure Search Service providers for indexing search.
+
+Lucene search provider not supported.
+

--- a/src/VirtoCommerce.ExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ExperienceApiModule.Web/module.manifest
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <id>VirtoCommerce.ExperienceApi</id>
   <version>0.21.0</version>
@@ -28,7 +28,6 @@
   <assemblyFile>VirtoCommerce.ExperienceApiModule.Web.dll</assemblyFile>
   <moduleType>VirtoCommerce.ExperienceApiModule.Web.Module, VirtoCommerce.ExperienceApiModule.Web</moduleType>
   <dependencies>
-    <dependency id="VirtoCommerce.ElasticSearch" version="3.0.2" />
     <dependency id="VirtoCommerce.Cart" version="3.2.0" />
     <dependency id="VirtoCommerce.Marketing" version="3.4.0" />
     <dependency id="VirtoCommerce.Inventory" version="3.2.0" />


### PR DESCRIPTION
### Related task:     
VP-6269 [X-API] As a platform user, I want to be able to install and use XAPI module without ElasticSearch module installed 

### Changes:

Remove VirtoCommerce.ElasticSearch module dependency
Add module limitation to documentation