### PR TITLE
VP-6701: [XAPI] Error in response if product does not have price

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.Core/Extensions/ResolveFieldContextExtensions.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Extensions/ResolveFieldContextExtensions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using GraphQL;
-using GraphQL.Types;
 using VirtoCommerce.CoreModule.Core.Common;
 using VirtoCommerce.CoreModule.Core.Currency;
 using VirtoCommerce.ExperienceApiModule.Core.Infrastructure;
@@ -110,6 +109,15 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Extensions
                 CustomFormatting = x.CustomFormatting
             }).ToArray();
             context.UserContext["allCurrencies"] = currenciesWithCulture;
+        }
+
+        public static void SetCurrency(this IResolveFieldContext context, Currency currency)
+        {
+            if (currency == null)
+            {
+                throw new ArgumentNullException(nameof(currency));
+            }
+            context.UserContext["currencyCode"] = currency.Code;
         }
 
         public static Currency GetCurrencyByCode<T>(this IResolveFieldContext<T> userContext, string currencyCode)

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Schemas/DigitalCatalogSchema.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Schemas/DigitalCatalogSchema.cs
@@ -76,7 +76,7 @@ namespace VirtoCommerce.XDigitalCatalog.Schemas
                 .Name("products")
                 .Argument<NonNullGraphType<StringGraphType>>("storeId", "The store id where products are searched")
                 .Argument<StringGraphType>("userId", "The customer id for search result impersonalization")
-                .Argument<StringGraphType>("currencyCode", "The currency for which all prices data will be returned")
+                .Argument<NonNullGraphType<StringGraphType>>("currencyCode", "The currency for which all prices data will be returned")
                 .Argument<StringGraphType>("cultureName", "The culture name for cart context product")
                 .Argument<StringGraphType>("query", "The query parameter performs the full-text search")
                 .Argument<StringGraphType>("filter", "This parameter applies a filter to the query results")

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Schemas/DigitalCatalogSchema.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Schemas/DigitalCatalogSchema.cs
@@ -76,7 +76,7 @@ namespace VirtoCommerce.XDigitalCatalog.Schemas
                 .Name("products")
                 .Argument<NonNullGraphType<StringGraphType>>("storeId", "The store id where products are searched")
                 .Argument<StringGraphType>("userId", "The customer id for search result impersonalization")
-                .Argument<NonNullGraphType<StringGraphType>>("currencyCode", "The currency for which all prices data will be returned")
+                .Argument<StringGraphType>("currencyCode", "The currency for which all prices data will be returned")
                 .Argument<StringGraphType>("cultureName", "The culture name for cart context product")
                 .Argument<StringGraphType>("query", "The query parameter performs the full-text search")
                 .Argument<StringGraphType>("filter", "This parameter applies a filter to the query results")
@@ -205,6 +205,12 @@ namespace VirtoCommerce.XDigitalCatalog.Schemas
             }
 
             var response = await mediator.Send(query);
+            var currencyCode = context.GetArgumentOrValue<string>("currencyCode");
+            if (string.IsNullOrWhiteSpace(currencyCode))
+            {
+                context.SetCurrency(response.Currency);
+            }
+            
             var result = new ProductsConnection<ExpProduct>(response.Results, skip, Convert.ToInt32(context.After ?? 0.ToString()), response.TotalCount)
             {
                 Facets = response.Facets


### PR DESCRIPTION
### Related task:     
   VP-6701 [XAPI] Error in response if product does not have price
### Problem:
 When product does not have price then error shown in response
"GraphQL.Execution.UnhandledError: Error trying to resolve field 'price'
C:\\Develop\\PlatformCoreModules\\vc-module-experience-api\\src\\VirtoCommerce.ExperienceApiModule.DigitalCatalog\\Schemas\\ProductType.cs:line 238"

https://github.com/VirtoCommerce/vc-module-experience-api/blob/3cf29f9ad090ea4e91860aeddbe7e9eceb78ca7a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Schemas/ProductType.cs#L238

### Solution:
Make currencyCode filed NotNullGraphType for product query 


