### PR TITLE
VP-6875: Optimize IndexFieldsMapper

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Index/IndexFieldsMapper.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Index/IndexFieldsMapper.cs
@@ -8,65 +8,78 @@ namespace VirtoCommerce.ExperienceApiModule.XDigitalCatalog.Index
     {
         public class RegexpNameMapper
         {
-            protected string Pattern { get; set; }
+            protected Regex _regex { get; set; }
+
             protected string Replacement { get; set; }
             public string[] AdditionalFields { get; set; }
 
             public RegexpNameMapper(string pattern, string replacement, string[] additionalFields = null)
             {
-                Pattern = pattern;
+                _regex = new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled);
                 Replacement = replacement;
                 AdditionalFields = additionalFields;
             }
 
             public virtual bool CanMap(string input)
             {
-                return Regex.IsMatch(input, Pattern, RegexOptions.IgnoreCase);
+                return _regex.IsMatch(input);
             }
 
             public virtual string Map(string input)
             {
-                return Regex.Replace(input, Pattern, Replacement, RegexOptions.IgnoreCase);
+                return _regex.Replace(input, Replacement);
             }
         }
 
-        public static IList<RegexpNameMapper> Mappers => new List<RegexpNameMapper>()
+        private static IList<RegexpNameMapper> _mappers;
+
+        public static IList<RegexpNameMapper> Mappers
         {
-            new RegexpNameMapper(@".*", "$0", new [] { "__object.id", "__object.categoryId", "__object.catalogId" }),
-            new RegexpNameMapper(@"(items.)?price[s]?.(?<part>[^\.]+).*$","__prices.$2", new [] { "__prices.currency" }),
-            new RegexpNameMapper(@"^items.variations", "__variations", new [] { "__variations" }),
-            new RegexpNameMapper(@"^variations", "__variations", new [] { "__variations" }),
-            new RegexpNameMapper(@"^items", "__object"),
-            new RegexpNameMapper(@"^(?!__)", "__object."),
+            get
+            {
+                if (_mappers == null)
+                {
+                    _mappers = new List<RegexpNameMapper>()
+                    {
+                        new RegexpNameMapper(@".*", "$0", new [] { "__object.id", "__object.categoryId", "__object.catalogId" }),
+                        new RegexpNameMapper(@"(items.)?price[s]?.(?<part>[^\.]+).*$","__prices.$2", new [] { "__prices.currency" }),
+                        new RegexpNameMapper(@"^items.variations", "__variations", new [] { "__variations" }),
+                        new RegexpNameMapper(@"^variations", "__variations", new [] { "__variations" }),
+                        new RegexpNameMapper(@"^items", "__object"),
+                        new RegexpNameMapper(@"^(?!__)", "__object."),
 
-         
-            new RegexpNameMapper(@"properties.value$", "properties.values"),
-            new RegexpNameMapper(@"imgSrc", "images"),
 
-            new RegexpNameMapper(@"__object.availabilityData.isActive", "__object.isActive"),
-            new RegexpNameMapper(@"__object.availabilityData.isBuyable", "__object.isBuyable"),
-            new RegexpNameMapper(@"__object.availabilityData.trackInventory", "__object.trackInventory"),
+                        new RegexpNameMapper(@"properties.value$", "properties.values"),
+                        new RegexpNameMapper(@"imgSrc", "images"),
 
-            new RegexpNameMapper(@"__object.parent.*",  "__object.parentId"),
-            new RegexpNameMapper(@"__object.hasParent.*", "__object.parentId"),
-            new RegexpNameMapper(@"__object.parent.*", "__object.parentId"),
+                        new RegexpNameMapper(@"__object.availabilityData.isActive", "__object.isActive"),
+                        new RegexpNameMapper(@"__object.availabilityData.isBuyable", "__object.isBuyable"),
+                        new RegexpNameMapper(@"__object.availabilityData.trackInventory", "__object.trackInventory"),
 
-            new RegexpNameMapper(@"__object.category.*", "__object.categoryId"),
-            new RegexpNameMapper(@"__object.descriptions", "__object.reviews"),
-            new RegexpNameMapper(@"__object.description.*", "__object.reviews"),
-            new RegexpNameMapper(@"__object.seoInfo.*", "__object.seoInfos"),
+                        new RegexpNameMapper(@"__object.parent.*",  "__object.parentId"),
+                        new RegexpNameMapper(@"__object.hasParent.*", "__object.parentId"),
+                        new RegexpNameMapper(@"__object.parent.*", "__object.parentId"),
 
-            #region Category
+                        new RegexpNameMapper(@"__object.category.*", "__object.categoryId"),
+                        new RegexpNameMapper(@"__object.descriptions", "__object.reviews"),
+                        new RegexpNameMapper(@"__object.description.*", "__object.reviews"),
+                        new RegexpNameMapper(@"__object.seoInfo.*", "__object.seoInfos"),
+
+                        #region Category
 		
-            new RegexpNameMapper(@"__object.slug$", "__object.outlines", new [] { "__object.seoInfos" }),
-            new RegexpNameMapper(@"__object.outline$", "__object.outlines"),
-            new RegexpNameMapper(@"__object.level$", "__object.outlines"), 
-	        #endregion
-        };
+                        new RegexpNameMapper(@"__object.slug$", "__object.outlines", new [] { "__object.seoInfos" }),
+                        new RegexpNameMapper(@"__object.outline$", "__object.outlines"),
+                        new RegexpNameMapper(@"__object.level$", "__object.outlines"), 
+	                    #endregion
+                    };
+                }
+                return _mappers;
+            }
+        }
 
         public static IEnumerable<string> MapToIndexIncludes(IEnumerable<string> includeFields)
         {
-            var result = new List<string>();
+            IEnumerable<string> result = new string[] { };
             foreach (var includeField in includeFields)
             {
                 var indexField = includeField;
@@ -75,15 +88,15 @@ namespace VirtoCommerce.ExperienceApiModule.XDigitalCatalog.Index
                     if (mapper.CanMap(indexField))
                     {
                         indexField = mapper.Map(indexField);
-                        if(mapper.AdditionalFields != null)
+                        if (mapper.AdditionalFields != null)
                         {
-                            result.AddRange(mapper.AdditionalFields);
+                            result = result.Union(mapper.AdditionalFields);
                         }
                     }
                 }
-                result.Add(indexField);
+                result = result.Union(new string[] { indexField });
             }
-            return result.Distinct();
+            return result;
         }
     }
     


### PR DESCRIPTION
This change allows to IndexFieldsMapper work 2x+ faster.
Because:
1. Regexes precompiled;
2. Mappers cached in process with precompiled regexes;
3. List and List.Distinct avoided calling.