### PR TITLE
VP-6264: Fix confirm payment request can create separate payment document

### DIFF
--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/CustomerOrderAggregate.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/CustomerOrderAggregate.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Linq;
 using VirtoCommerce.CoreModule.Core.Currency;
 using VirtoCommerce.OrdersModule.Core.Model;
+using VirtoCommerce.PaymentModule.Core.Model;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Domain;
 
@@ -23,30 +25,36 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder
             Order.Status = status;
         }
 
-        public void CancelOrderPayment(PaymentIn payment)
+        public bool CancelOrderPayment(PaymentIn payment)
         {
             var paymentOrder = Order.InPayments.FirstOrDefault(x => x.Number.EqualsInvariant(payment.Number));
             if (paymentOrder != null)
             {
-                paymentOrder.IsCancelled = payment.IsCancelled;
-                paymentOrder.CancelReason = payment.CancelReason;
-                paymentOrder.CancelledDate = payment.CancelledDate;
-                paymentOrder.Status = payment.Status;
+                paymentOrder.IsCancelled = true;
+                paymentOrder.CancelReason = payment.CancelReason ?? paymentOrder.CancelReason;
+                paymentOrder.CancelledDate = payment.CancelledDate ?? DateTime.Now;
+                paymentOrder.Status = PaymentStatus.Cancelled.ToString();
+                paymentOrder.PaymentStatus = PaymentStatus.Cancelled;
+                return true;
             }
+
+            return false;
         }
 
-        public void ConfirmOrderPayment(PaymentIn payment)
+        public bool ConfirmOrderPayment(PaymentIn payment)
         {
             var paymentOrder = Order.InPayments.FirstOrDefault(x => x.Number.EqualsInvariant(payment.Number));
-            if (paymentOrder == null)
-            {
-                paymentOrder = payment;
-                Order.InPayments.Add(paymentOrder);
-            }
-            else
+            if (paymentOrder != null)
             {
                 paymentOrder.BillingAddress = payment.BillingAddress;
+                paymentOrder.IsApproved = true;
+                paymentOrder.IsCancelled = false;
+                paymentOrder.PaymentStatus = PaymentStatus.Paid;
+                paymentOrder.Status = PaymentStatus.Paid.ToString();
+                return true;
             }
+
+            return false;
         }
     }
 }

--- a/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/Aggregates/CustomerOrderAggregateTests.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/Aggregates/CustomerOrderAggregateTests.cs
@@ -1,0 +1,119 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using VirtoCommerce.CoreModule.Core.Common;
+using VirtoCommerce.CoreModule.Core.Currency;
+using VirtoCommerce.ExperienceApiModule.XOrder;
+using VirtoCommerce.OrdersModule.Core.Model;
+using VirtoCommerce.PaymentModule.Core.Model;
+using VirtoCommerce.XPurchase.Tests.Helpers;
+using Xunit;
+
+namespace VirtoCommerce.XPurchase.Tests.Aggregates
+{
+    public class CustomerOrderAggregateTests : XPurchaseMoqHelper
+    {
+        [Fact]
+        public void CancelPaymentTest_PaymentCancelled()
+        {
+            //Arrange
+            var aggregate = new CustomerOrderAggregate(CreateNewOrder(), new Currency(Language.InvariantLanguage, "USD"));
+            var existPayment = new PaymentIn()
+            {
+              Number = "92321873-2E99-44B0-A50C-0A0883C9B137"
+            };
+
+            //Act
+            var result = aggregate.CancelOrderPayment(existPayment);
+
+            //Assert
+            result.Should().BeTrue();
+            aggregate.Order.InPayments.Should().HaveCount(1);
+            aggregate.Order.InPayments.First().PaymentStatus.Should().Be(PaymentStatus.Cancelled);
+            aggregate.Order.InPayments.First().Status.Should().Be(PaymentStatus.Cancelled.ToString());
+            aggregate.Order.InPayments.First().IsCancelled.Should().BeTrue();
+        }
+
+        [Fact]
+        public void CancelPaymentTest_PaymentNotDuplicate_PaymentNotCancelled()
+        {
+            //Arrange
+            var aggregate = new CustomerOrderAggregate(CreateNewOrder(), new Currency(Language.InvariantLanguage, "USD"));
+            var newPayment = new PaymentIn()
+            {
+                Number = "newPaymentNumber"
+            };
+
+            //Act
+            var result = aggregate.CancelOrderPayment(newPayment);
+
+            //Assert
+            result.Should().BeFalse();
+            aggregate.Order.InPayments.Should().HaveCount(1);
+            aggregate.Order.InPayments.First().PaymentStatus.Should().Be(PaymentStatus.New);
+            aggregate.Order.InPayments.First().Status.Should().Be(PaymentStatus.New.ToString());
+            aggregate.Order.InPayments.First().IsCancelled.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ConfirmPaymentTest_PaymentConfirmed()
+        {
+            //Arrange
+            var aggregate = new CustomerOrderAggregate(CreateNewOrder(), new Currency(Language.InvariantLanguage, "USD"));
+            var existPayment = new PaymentIn()
+            {
+                Number = "92321873-2E99-44B0-A50C-0A0883C9B137"
+            };
+
+            //Act
+            var result = aggregate.ConfirmOrderPayment(existPayment);
+
+            //Assert
+            result.Should().BeTrue();
+            aggregate.Order.InPayments.Should().HaveCount(1);
+            aggregate.Order.InPayments.First().PaymentStatus.Should().Be(PaymentStatus.Paid);
+            aggregate.Order.InPayments.First().Status.Should().Be(PaymentStatus.Paid.ToString());
+            aggregate.Order.InPayments.First().IsApproved.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ConfirmPaymentTest_PaymentNotDuplicate_PaymentNotConfirmed()
+        {
+            //Arrange
+            var aggregate = new CustomerOrderAggregate(CreateNewOrder(), new Currency(Language.InvariantLanguage, "USD"));
+            var newPayment = new PaymentIn()
+            {
+                Number = "newPaymentNumber"
+            };
+
+            //Act
+            var result = aggregate.ConfirmOrderPayment(newPayment);
+
+            //Assert
+            result.Should().BeFalse();
+            aggregate.Order.InPayments.Should().HaveCount(1);
+            aggregate.Order.InPayments.First().PaymentStatus.Should().Be(PaymentStatus.New);
+            aggregate.Order.InPayments.First().Status.Should().Be(PaymentStatus.New.ToString());
+            aggregate.Order.InPayments.First().IsApproved.Should().BeFalse();
+        }
+
+        public CustomerOrder CreateNewOrder()
+        {
+            return new CustomerOrder()
+            {
+                Id = "7BF30A9B-4447-448A-85CC-0B943B7F6B21",
+                InPayments = new List<PaymentIn>
+                {
+                    new PaymentIn()
+                    {
+                        Number = "92321873-2E99-44B0-A50C-0A0883C9B137",
+                        PaymentStatus = PaymentStatus.New,
+                        Status = PaymentStatus.New.ToString(),
+                        IsCancelled = false,
+                        IsApproved = false
+                    }
+                }
+            };
+        }
+    }
+}

--- a/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/VirtoCommerce.XPurchase.Tests.csproj
+++ b/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/VirtoCommerce.XPurchase.Tests.csproj
@@ -23,6 +23,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\tests\VirtoCommerce.ExperienceApiModule.Tests\VirtoCommerce.ExperienceApiModule.Tests.csproj" />
+        <ProjectReference Include="..\VirtoCommerce.ExperienceApiModule.XOrder\VirtoCommerce.ExperienceApiModule.XOrder.csproj" />
         <ProjectReference Include="..\VirtoCommerce.XPurchase\VirtoCommerce.XPurchase.csproj" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
https://virtocommerce.atlassian.net/browse/VP-6263 The payment status remains the same after cancelled
https://virtocommerce.atlassian.net/browse/VP-6264 Confirm payment request can create separate payment document


Fix the issue with setting any payment status when calling confirmOrderPayment or cancelOrderPayment
Fix issue with new payment creation when calling confirmOrderPayment or cancelOrderPayment
Add tests