### PR TITLE
PT-2810: Eliminate call Equals for null locales

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.Core/Services/DynamicPropertyUpdaterService.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Services/DynamicPropertyUpdaterService.cs
@@ -105,7 +105,7 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Services
             // override only values of a specific locale for multilingual property. Except dictionary properties.
             if (source.IsMultilingual && !source.IsDictionary)
             {
-                var comparer = AnonymousComparer.Create((DynamicPropertyObjectValue x) => x.Locale);
+                var comparer = AnonymousComparer.Create((DynamicPropertyObjectValue x) => x.Locale ?? string.Empty);
 
                 // fill missing values with the original ones. (That enables single value updates)
                 source.Values = source.Values.Union(target.Values, comparer).ToArray();


### PR DESCRIPTION
The reason is to emulate non-null locale to correctly use in compare in case of null dynamic property value locale

https://virtocommerce.atlassian.net/browse/PT-2808
