### PR TITLE
VDS-2491: Make createUser mutation anonymous

### DIFF
--- a/src/XProfile/VirtoCommerce.XProfile/Authorization/ProfileAuthorizationHandler.cs
+++ b/src/XProfile/VirtoCommerce.XProfile/Authorization/ProfileAuthorizationHandler.cs
@@ -44,33 +44,7 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Authorization
             var currentUserId = GetUserId(context);
             var currentContact = await GetCustomerAsync(currentUserId) as Contact;
 
-            if (context.Resource is ContactAggregate contactAggregate && currentContact != null)
-            {
-                result = currentContact.Id == contactAggregate.Contact.Id;
-                if (!result)
-                {
-                    result = await HasSameOrganizationAsync(currentContact, contactAggregate.Contact.Id);
-                }
-            }
-            else if (context.Resource is ApplicationUser applicationUser)
-            {
-                result = currentUserId == applicationUser.Id;
-                if (!result)
-                {
-                    result = await HasSameOrganizationAsync(currentContact, applicationUser.Id);
-                }
-            }
-            else if (context.Resource is OrganizationAggregate organizationAggregate && currentContact != null)
-            {
-                result = currentContact.Organizations.Contains(organizationAggregate.Organization.Id);
-            }
-
-            else if (context.Resource is Role role)
-            {
-                //Can be checked only with platform permission
-                result = true;
-            }
-            else if (context.Resource is CreateContactCommand createContactCommand)
+            if (context.Resource is CreateContactCommand createContactCommand)
             {
                 //Anonymous user can create contact
                 result = true;
@@ -149,6 +123,32 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Authorization
             else if (context.Resource is UpdatePersonalDataCommand updatePersonalDataCommand)
             {
                 updatePersonalDataCommand.UserId = currentUserId;
+                result = true;
+            }
+            else if (context.Resource is ContactAggregate contactAggregate && currentContact != null)
+            {
+                result = currentContact.Id == contactAggregate.Contact.Id;
+                if (!result)
+                {
+                    result = await HasSameOrganizationAsync(currentContact, contactAggregate.Contact.Id);
+                }
+            }
+            else if (context.Resource is ApplicationUser applicationUser)
+            {
+                result = currentUserId == applicationUser.Id;
+                if (!result)
+                {
+                    result = await HasSameOrganizationAsync(currentContact, applicationUser.Id);
+                }
+            }
+            else if (context.Resource is OrganizationAggregate organizationAggregate && currentContact != null)
+            {
+                result = currentContact.Organizations.Contains(organizationAggregate.Organization.Id);
+            }
+
+            else if (context.Resource is Role role)
+            {
+                //Can be checked only with platform permission
                 result = true;
             }
             if (result)


### PR DESCRIPTION
## Description
This is temporary artefact for vc-demo-xapi-app 

Why we shouldn't fix it that way:
1. `createUser` didn't allowed anonymous usage because of bug
2. Bug was caused because `createUser` command is inherited from the `ApplicationUser` which itself returned as result of query `user` and checked above `createUser` command check
3. `createContact` and `createOrganization` doesn't affected by bug because they use aggregates (which is redundant because nothing returned by their queries than objects itself)
4. `createUser` has `UserType` and `IsAdministrator` parameters, which will lead to security vulnerability if we will allow to call this mutation  anonymously

## References
### QA-test:
### Jira-link:
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_1.23.0-pr-179.zip
