### PR TITLE
PT-3386: All handlers methods defined as virtual to allow override

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.Core/Queries/GetCountriesQueryHandler.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Queries/GetCountriesQueryHandler.cs
@@ -18,7 +18,7 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Queries
         /// <summary>
         /// Return countries list
         /// </summary>
-        public async Task<GetCountriesResponse> Handle(GetCountriesQuery request, CancellationToken cancellationToken)
+        public virtual async Task<GetCountriesResponse> Handle(GetCountriesQuery request, CancellationToken cancellationToken)
         {
             var countries = await _countriesService.GetCountriesAsync();
             var result = new GetCountriesResponse { Countries = countries };
@@ -29,7 +29,7 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Queries
         /// <summary>
         /// Return regions of the country
         /// </summary>
-        public async Task<GetRegionsResponse> Handle(GetRegionsQuery request, CancellationToken cancellationToken)
+        public virtual async Task<GetRegionsResponse> Handle(GetRegionsQuery request, CancellationToken cancellationToken)
         {
             var regions = await _countriesService.GetCountryRegionsAsync(request.CountryId);
             var result = new GetRegionsResponse() { Regions = regions };

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/LoadRelatedCatalogOutlineQueryHandler.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/LoadRelatedCatalogOutlineQueryHandler.cs
@@ -15,7 +15,7 @@ namespace VirtoCommerce.XDigitalCatalog.Queries
             _storeService = storeService;
         }
 
-        public async Task<LoadRelatedCatalogOutlineResponse> Handle(LoadRelatedCatalogOutlineQuery request, CancellationToken cancellationToken)
+        public virtual async Task<LoadRelatedCatalogOutlineResponse> Handle(LoadRelatedCatalogOutlineQuery request, CancellationToken cancellationToken)
         {
             var store = await _storeService.GetByIdAsync(request.StoreId);
             if (store is null) return new LoadRelatedCatalogOutlineResponse();

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/LoadRelatedSlugPathQueryHandler.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/LoadRelatedSlugPathQueryHandler.cs
@@ -15,7 +15,7 @@ namespace VirtoCommerce.XDigitalCatalog.Queries
             _storeService = storeService;
         }
 
-        public async Task<LoadRelatedSlugPathResponse> Handle(LoadRelatedSlugPathQuery request, CancellationToken cancellationToken)
+        public virtual async Task<LoadRelatedSlugPathResponse> Handle(LoadRelatedSlugPathQuery request, CancellationToken cancellationToken)
         {
             var store = await _storeService.GetByIdAsync(request.StoreId);
             if (store is null) return new LoadRelatedSlugPathResponse();

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/SearchProductAssociationsQueryHandler.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/SearchProductAssociationsQueryHandler.cs
@@ -18,7 +18,7 @@ namespace VirtoCommerce.XDigitalCatalog.Queries
             _productAssociationSearchService = productAssociationSearchService;
         }
 
-        public async Task<SearchProductAssociationsResponse> Handle(SearchProductAssociationsQuery request, CancellationToken cancellationToken)
+        public virtual async Task<SearchProductAssociationsResponse> Handle(SearchProductAssociationsQuery request, CancellationToken cancellationToken)
         {
             var result = await _productAssociationSearchService.SearchProductAssociationsAsync(_mapper.Map<ProductAssociationSearchCriteria>(request));
 

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/SearchPropertiesQueryHandler.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/SearchPropertiesQueryHandler.cs
@@ -22,7 +22,7 @@ namespace VirtoCommerce.XDigitalCatalog.Queries
             _propertySearchService = propertySearchService;
         }
 
-        public async Task<SearchPropertiesResponse> Handle(SearchPropertiesQuery request, CancellationToken cancellationToken)
+        public virtual async Task<SearchPropertiesResponse> Handle(SearchPropertiesQuery request, CancellationToken cancellationToken)
         {
             var searchCriteria = new PropertySearchCriteriaBuilder(_searchPhraseParser, _mapper)
                             .ParseFilters(request.Filter)

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/SearchPropertyDictionaryItemQueryHandler.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/SearchPropertyDictionaryItemQueryHandler.cs
@@ -18,7 +18,7 @@ namespace VirtoCommerce.XDigitalCatalog.Queries
             _propertyDictionaryItemSearchService = propertyDictionaryItemSearchService;
         }
 
-        public async Task<SearchPropertyDictionaryItemResponse> Handle(SearchPropertyDictionaryItemQuery request, CancellationToken cancellationToken)
+        public virtual async Task<SearchPropertyDictionaryItemResponse> Handle(SearchPropertyDictionaryItemQuery request, CancellationToken cancellationToken)
         {
             var result = await _propertyDictionaryItemSearchService.SearchAsync(_mapper.Map<PropertyDictionaryItemSearchCriteria>(request));
 

--- a/src/XProfile/VirtoCommerce.XProfile/Commands/CreateContactCommandHandler.cs
+++ b/src/XProfile/VirtoCommerce.XProfile/Commands/CreateContactCommandHandler.cs
@@ -20,7 +20,7 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Commands
             _validator = validator;
         }
 
-        public async Task<ContactAggregate> Handle(CreateContactCommand request, CancellationToken cancellationToken)
+        public virtual async Task<ContactAggregate> Handle(CreateContactCommand request, CancellationToken cancellationToken)
         {
             request.MemberType = nameof(Contact);
 

--- a/src/XProfile/VirtoCommerce.XProfile/Commands/CreateOrganizationCommandHandler.cs
+++ b/src/XProfile/VirtoCommerce.XProfile/Commands/CreateOrganizationCommandHandler.cs
@@ -19,7 +19,7 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Commands
             _memberAggregateFactory = factory;
         }
 
-        public async Task<OrganizationAggregate> Handle(CreateOrganizationCommand request, CancellationToken cancellationToken)
+        public virtual async Task<OrganizationAggregate> Handle(CreateOrganizationCommand request, CancellationToken cancellationToken)
         {
             var org = _mapper.Map<Organization>(request);
             var orgAggr = _memberAggregateFactory.Create<OrganizationAggregate>(org);

--- a/src/XProfile/VirtoCommerce.XProfile/Commands/CreateUserCommandHandler.cs
+++ b/src/XProfile/VirtoCommerce.XProfile/Commands/CreateUserCommandHandler.cs
@@ -20,7 +20,7 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Commands
             _storeNotificationSender = storeNotificationSender;
         }
 
-        public async Task<IdentityResult> Handle(CreateUserCommand request, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> Handle(CreateUserCommand request, CancellationToken cancellationToken)
         {
             using (var userManager = _userManagerFactory())
             {

--- a/src/XProfile/VirtoCommerce.XProfile/Commands/DeleteContactCommandHandler.cs
+++ b/src/XProfile/VirtoCommerce.XProfile/Commands/DeleteContactCommandHandler.cs
@@ -11,7 +11,7 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Commands
         {
             _contactAggregateRepository = contactAggregateRepository;
         }
-        public async Task<bool> Handle(DeleteContactCommand request, CancellationToken cancellationToken)
+        public virtual async Task<bool> Handle(DeleteContactCommand request, CancellationToken cancellationToken)
         {
             await _contactAggregateRepository.DeleteAsync(request.ContactId);
 

--- a/src/XProfile/VirtoCommerce.XProfile/Commands/DeleteUserCommandHandler.cs
+++ b/src/XProfile/VirtoCommerce.XProfile/Commands/DeleteUserCommandHandler.cs
@@ -18,7 +18,7 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Commands
         {
         }
 
-        public async Task<IdentityResult> Handle(DeleteUserCommand request, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> Handle(DeleteUserCommand request, CancellationToken cancellationToken)
         {
             if (request.UserNames.Any(x => !IsUserEditable(x)))
             {

--- a/src/XProfile/VirtoCommerce.XProfile/Commands/SearchMembersQueryHandler.cs
+++ b/src/XProfile/VirtoCommerce.XProfile/Commands/SearchMembersQueryHandler.cs
@@ -19,14 +19,14 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Commands
             _memberSearchService = memberSearchService;
         }
 
-        public Task<MemberSearchResult> Handle(SearchContactsQuery request, CancellationToken cancellationToken)
+        public virtual Task<MemberSearchResult> Handle(SearchContactsQuery request, CancellationToken cancellationToken)
         {
             var searchCriteria = BuildMembersSearchCriteria(request, nameof(Contact));
 
             return _memberSearchService.SearchMembersAsync(searchCriteria);
         }
 
-        public Task<MemberSearchResult> Handle(SearchOrganizationsQuery request, CancellationToken cancellationToken)
+        public virtual Task<MemberSearchResult> Handle(SearchOrganizationsQuery request, CancellationToken cancellationToken)
         {
             var searchCriteria = BuildMembersSearchCriteria(request, nameof(Organization));
 

--- a/src/XProfile/VirtoCommerce.XProfile/Commands/SendVerifyEmailCommandHandler.cs
+++ b/src/XProfile/VirtoCommerce.XProfile/Commands/SendVerifyEmailCommandHandler.cs
@@ -20,7 +20,7 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Commands
             _storeNotificationSender = storeNotificationSender;
         }
 
-        public async Task<bool> Handle(SendVerifyEmailCommand request, CancellationToken cancellationToken)
+        public virtual async Task<bool> Handle(SendVerifyEmailCommand request, CancellationToken cancellationToken)
         {
             using (var userManager = _userManagerFactory())
             {

--- a/src/XProfile/VirtoCommerce.XProfile/Commands/UpdateContactAddressesCommandHandler.cs
+++ b/src/XProfile/VirtoCommerce.XProfile/Commands/UpdateContactAddressesCommandHandler.cs
@@ -13,7 +13,7 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Commands
             _contactAggregateRepository = contactAggregateRepository;
         }
 
-        public async Task<ContactAggregate> Handle(UpdateContactAddressesCommand request, CancellationToken cancellationToken)
+        public virtual async Task<ContactAggregate> Handle(UpdateContactAddressesCommand request, CancellationToken cancellationToken)
         {
             var contactAggregate = await _contactAggregateRepository.GetMemberAggregateRootByIdAsync<ContactAggregate>(request.ContactId);
             contactAggregate.UpdateAddresses(request.Addresses);

--- a/src/XProfile/VirtoCommerce.XProfile/Commands/UpdateContactCommandHandler.cs
+++ b/src/XProfile/VirtoCommerce.XProfile/Commands/UpdateContactCommandHandler.cs
@@ -14,7 +14,7 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Commands
             _contactAggregateRepository = contactAggregateRepository;
             _memberAggregateFactory = factory;
         }
-        public async Task<ContactAggregate> Handle(UpdateContactCommand request, CancellationToken cancellationToken)
+        public virtual async Task<ContactAggregate> Handle(UpdateContactCommand request, CancellationToken cancellationToken)
         {
             var contactAggregate = _memberAggregateFactory.Create<ContactAggregate>(request);
 

--- a/src/XProfile/VirtoCommerce.XProfile/Commands/UpdateMemberDynamicPropertiesCommandHandler.cs
+++ b/src/XProfile/VirtoCommerce.XProfile/Commands/UpdateMemberDynamicPropertiesCommandHandler.cs
@@ -17,7 +17,7 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Commands
             _dynamicPropertyUpdater = dynamicPropertyUpdater;
         }
 
-        public async Task<IMemberAggregateRoot> Handle(UpdateMemberDynamicPropertiesCommand request, CancellationToken cancellationToken)
+        public virtual async Task<IMemberAggregateRoot> Handle(UpdateMemberDynamicPropertiesCommand request, CancellationToken cancellationToken)
         {
             var memberAggregate = await _contactAggregateRepository.GetMemberAggregateRootByIdAsync<MemberAggregateRootBase>(request.MemberId);
 

--- a/src/XProfile/VirtoCommerce.XProfile/Commands/UpdateOrganizationCommandHandler.cs
+++ b/src/XProfile/VirtoCommerce.XProfile/Commands/UpdateOrganizationCommandHandler.cs
@@ -16,7 +16,7 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Commands
             _organizationAggregateRepository = organizationAggregateRepository;
         }
 
-        public async Task<OrganizationAggregate> Handle(UpdateOrganizationCommand request, CancellationToken cancellationToken)
+        public virtual async Task<OrganizationAggregate> Handle(UpdateOrganizationCommand request, CancellationToken cancellationToken)
         {
             var organizationAggregate = await _organizationAggregateRepository.GetMemberAggregateRootByIdAsync<OrganizationAggregate>(request.Id);
             _mapper.Map(request, organizationAggregate.Organization);

--- a/src/XProfile/VirtoCommerce.XProfile/Commands/UpdatePersonalDataCommandHandler.cs
+++ b/src/XProfile/VirtoCommerce.XProfile/Commands/UpdatePersonalDataCommandHandler.cs
@@ -22,7 +22,7 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Commands
             _contactAggregateRepository = contactAggregateRepository;
         }
 
-        public async Task<IdentityResult> Handle(UpdatePersonalDataCommand request, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> Handle(UpdatePersonalDataCommand request, CancellationToken cancellationToken)
         {
             var result = IdentityResult.Success;
             using (var userManager = _userManagerFactory())

--- a/src/XProfile/VirtoCommerce.XProfile/Commands/UpdateRoleCommandHandler.cs
+++ b/src/XProfile/VirtoCommerce.XProfile/Commands/UpdateRoleCommandHandler.cs
@@ -18,7 +18,7 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Commands
             _services = services;
         }
 
-        public async Task<IdentityResult> Handle(UpdateRoleCommand request, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> Handle(UpdateRoleCommand request, CancellationToken cancellationToken)
         {
             IdentityResult result;
 

--- a/src/XProfile/VirtoCommerce.XProfile/Commands/UpdateUserCommandHandler.cs
+++ b/src/XProfile/VirtoCommerce.XProfile/Commands/UpdateUserCommandHandler.cs
@@ -15,7 +15,7 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Commands
         {
         }
 
-        public async Task<IdentityResult> Handle(UpdateUserCommand request, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> Handle(UpdateUserCommand request, CancellationToken cancellationToken)
         {
             if (!IsUserEditable(request.UserName))
             {

--- a/src/XProfile/VirtoCommerce.XProfile/Queries/GetContactByIdQueryHandler.cs
+++ b/src/XProfile/VirtoCommerce.XProfile/Queries/GetContactByIdQueryHandler.cs
@@ -13,7 +13,7 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Queries
             _contactAggregateRepository = contactAggregateRepository;
         }
 
-        public Task<ContactAggregate> Handle(GetContactByIdQuery request, CancellationToken cancellationToken)
+        public virtual Task<ContactAggregate> Handle(GetContactByIdQuery request, CancellationToken cancellationToken)
         {
             return _contactAggregateRepository.GetMemberAggregateRootByIdAsync<ContactAggregate>(request.ContactId);
         }

--- a/src/XProfile/VirtoCommerce.XProfile/Queries/GetOrganizationByIdQueryHandler.cs
+++ b/src/XProfile/VirtoCommerce.XProfile/Queries/GetOrganizationByIdQueryHandler.cs
@@ -13,7 +13,7 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Queries
             _organizationAggregateRepository = organizationAggregateRepository;
         }
 
-        public Task<OrganizationAggregate> Handle(GetOrganizationByIdQuery request, CancellationToken cancellationToken)
+        public virtual Task<OrganizationAggregate> Handle(GetOrganizationByIdQuery request, CancellationToken cancellationToken)
         {
             return _organizationAggregateRepository.GetMemberAggregateRootByIdAsync<OrganizationAggregate>(request.OrganizationId);
         }

--- a/src/XProfile/VirtoCommerce.XProfile/Queries/GetRoleQueryHandler.cs
+++ b/src/XProfile/VirtoCommerce.XProfile/Queries/GetRoleQueryHandler.cs
@@ -17,7 +17,7 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Queries
             _services = services;
         }
 
-        public async Task<Role> Handle(GetRoleQuery request, CancellationToken cancellationToken)
+        public virtual async Task<Role> Handle(GetRoleQuery request, CancellationToken cancellationToken)
         {
             using var scope = _services.CreateScope();
             var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<Role>>();

--- a/src/XProfile/VirtoCommerce.XProfile/Queries/GetUserQueryHandler.cs
+++ b/src/XProfile/VirtoCommerce.XProfile/Queries/GetUserQueryHandler.cs
@@ -19,7 +19,7 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Queries
             _userManagerFactory = userManager;
         }
 
-        public async Task<ApplicationUser> Handle(GetUserQuery request, CancellationToken cancellationToken)
+        public virtual async Task<ApplicationUser> Handle(GetUserQuery request, CancellationToken cancellationToken)
         {
             ApplicationUser result = default;
 

--- a/src/XProfile/VirtoCommerce.XProfile/Queries/SearchOrganizationMembersQueryHandler.cs
+++ b/src/XProfile/VirtoCommerce.XProfile/Queries/SearchOrganizationMembersQueryHandler.cs
@@ -16,7 +16,7 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Queries
             _memberSearchService = memberSearchService;
         }
 
-        public async Task<MemberSearchResult> Handle(SearchOrganizationMembersQuery request, CancellationToken cancellationToken)
+        public virtual async Task<MemberSearchResult> Handle(SearchOrganizationMembersQuery request, CancellationToken cancellationToken)
         {
             var criteria = new MembersSearchCriteria
             {

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/ChangeOrderStatusCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/ChangeOrderStatusCommandHandler.cs
@@ -14,7 +14,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
             _customerOrderService = customerOrderService;
             _customerOrderAggregateRepository = customerOrderAggregateRepository;
         }
-        public async Task<bool> Handle(ChangeOrderStatusCommand request, CancellationToken cancellationToken)
+        public virtual async Task<bool> Handle(ChangeOrderStatusCommand request, CancellationToken cancellationToken)
         {
             var orderAggregate = await _customerOrderAggregateRepository.GetOrderByIdAsync(request.OrderId);
             orderAggregate.ChangeOrderStatus(request.Status);

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/ConfirmOrCancelOrderPaymentCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/ConfirmOrCancelOrderPaymentCommandHandler.cs
@@ -16,7 +16,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
             _customerOrderAggregateRepository = customerOrderAggregateRepository;
         }
 
-        public async Task<bool> Handle(CancelOrderPaymentCommand request, CancellationToken cancellationToken)
+        public virtual async Task<bool> Handle(CancelOrderPaymentCommand request, CancellationToken cancellationToken)
         {
             var orderAggregate = await _customerOrderAggregateRepository.GetOrderByIdAsync(request.Payment.OrderId);
             var paymentCancelledSuccessful = orderAggregate.CancelOrderPayment(request.Payment);
@@ -28,7 +28,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
             return paymentCancelledSuccessful;
         }
 
-        public async Task<bool> Handle(ConfirmOrderPaymentCommand request, CancellationToken cancellationToken)
+        public virtual async Task<bool> Handle(ConfirmOrderPaymentCommand request, CancellationToken cancellationToken)
         {
             var orderAggregate = await _customerOrderAggregateRepository.GetOrderByIdAsync(request.Payment.OrderId);
             var paymentConfirmedSuccessful = orderAggregate.ConfirmOrderPayment(request.Payment);

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/UpdateOrderDynamicPropertiesCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/UpdateOrderDynamicPropertiesCommandHandler.cs
@@ -16,7 +16,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
             _customerOrderAggregateRepository = customerOrderAggregateRepository;
         }
 
-        public async Task<CustomerOrderAggregate> Handle(UpdateOrderDynamicPropertiesCommand request, CancellationToken cancellationToken)
+        public virtual async Task<CustomerOrderAggregate> Handle(UpdateOrderDynamicPropertiesCommand request, CancellationToken cancellationToken)
         {
             var orderAggregate = await _customerOrderAggregateRepository.GetOrderByIdAsync(request.OrderId);
 

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/UpdateOrderItemDynamicPropertiesCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/UpdateOrderItemDynamicPropertiesCommandHandler.cs
@@ -16,7 +16,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
             _customerOrderAggregateRepository = customerOrderAggregateRepository;
         }
 
-        public async Task<CustomerOrderAggregate> Handle(UpdateOrderItemDynamicPropertiesCommand request, CancellationToken cancellationToken)
+        public virtual async Task<CustomerOrderAggregate> Handle(UpdateOrderItemDynamicPropertiesCommand request, CancellationToken cancellationToken)
         {
             var orderAggregate = await _customerOrderAggregateRepository.GetOrderByIdAsync(request.OrderId);
 

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/UpdateOrderPaymentDynamicPropertiesCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/UpdateOrderPaymentDynamicPropertiesCommandHandler.cs
@@ -16,7 +16,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
             _customerOrderAggregateRepository = customerOrderAggregateRepository;
         }
 
-        public async Task<CustomerOrderAggregate> Handle(UpdateOrderPaymentDynamicPropertiesCommand request, CancellationToken cancellationToken)
+        public virtual async Task<CustomerOrderAggregate> Handle(UpdateOrderPaymentDynamicPropertiesCommand request, CancellationToken cancellationToken)
         {
             var orderAggregate = await _customerOrderAggregateRepository.GetOrderByIdAsync(request.OrderId);
 

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/UpdateOrderShipmentDynamicPropertiesCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/UpdateOrderShipmentDynamicPropertiesCommandHandler.cs
@@ -16,7 +16,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
             _customerOrderAggregateRepository = customerOrderAggregateRepository;
         }
 
-        public async Task<CustomerOrderAggregate> Handle(UpdateOrderShipmentDynamicPropertiesCommand request, CancellationToken cancellationToken)
+        public virtual async Task<CustomerOrderAggregate> Handle(UpdateOrderShipmentDynamicPropertiesCommand request, CancellationToken cancellationToken)
         {
             var orderAggregate = await _customerOrderAggregateRepository.GetOrderByIdAsync(request.OrderId);
 

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Queries/GetOrderQueryHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Queries/GetOrderQueryHandler.cs
@@ -18,7 +18,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Queries
             _customerOrderSearchService = customerOrderSearchService;
         }
 
-        public async Task<CustomerOrderAggregate> Handle(GetOrderQuery request, CancellationToken cancellationToken)
+        public virtual async Task<CustomerOrderAggregate> Handle(GetOrderQuery request, CancellationToken cancellationToken)
         {
             CustomerOrderAggregate result;
             if (!string.IsNullOrEmpty(request.OrderId))

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Queries/SearchOrderQueryHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Queries/SearchOrderQueryHandler.cs
@@ -21,7 +21,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Queries
             _customerOrderSearchService = customerOrderSearchService;
         }
 
-        public async Task<SearchOrderResponse> Handle(SearchOrderQuery request, CancellationToken cancellationToken)
+        public virtual async Task<SearchOrderResponse> Handle(SearchOrderQuery request, CancellationToken cancellationToken)
         {
             var searchCriteria = new CustomerOrderSearchCriteriaBuilder(_searchPhraseParser)
                                         .ParseFilters(request.Filter)

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Queries/SearchPaymentsQueryHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Queries/SearchPaymentsQueryHandler.cs
@@ -23,7 +23,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Queries
             _paymentsSearchService = paymentsSearchService;
         }
 
-        public async Task<PaymentSearchResult> Handle(SearchPaymentsQuery request, CancellationToken cancellationToken)
+        public virtual async Task<PaymentSearchResult> Handle(SearchPaymentsQuery request, CancellationToken cancellationToken)
         {
             var searchCriteria = new PaymentsSearchCriteriaBuilder(_searchPhraseParser, _mapper)
                                         .ParseFilters(request.Filter)

--- a/src/XPurchase/VirtoCommerce.XPurchase/Commands/ValidateCouponCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Commands/ValidateCouponCommandHandler.cs
@@ -13,7 +13,7 @@ namespace VirtoCommerce.XPurchase.Commands
 
         private ICartAggregateRepository CartAggrRepository { get; set; }
 
-        public async Task<bool> Handle(ValidateCouponCommand request, CancellationToken cancellationToken)
+        public virtual async Task<bool> Handle(ValidateCouponCommand request, CancellationToken cancellationToken)
         {
             var cartAggregate = await GetCartAggregateFromCommandAsync(request);
 
@@ -28,7 +28,7 @@ namespace VirtoCommerce.XPurchase.Commands
             return false;
         }
 
-        protected Task<CartAggregate> GetCartAggregateFromCommandAsync(ValidateCouponCommand request)
+        protected virtual Task<CartAggregate> GetCartAggregateFromCommandAsync(ValidateCouponCommand request)
         {
             return CartAggrRepository.GetCartAsync(request.CartName, request.StoreId, request.UserId, request.CultureName, request.CurrencyCode, request.CartType);
         }

--- a/src/XPurchase/VirtoCommerce.XPurchase/Queries/SearchCartQueryHandler.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Queries/SearchCartQueryHandler.cs
@@ -24,7 +24,7 @@ namespace VirtoCommerce.XPurchase.Queries
             _searchPhraseParser = searchPhraseParser;
         }
 
-        public Task<SearchCartResponse> Handle(SearchCartQuery request, CancellationToken cancellationToken)
+        public virtual Task<SearchCartResponse> Handle(SearchCartQuery request, CancellationToken cancellationToken)
         {
             var searchCriteria = new CartSearchCriteriaBuilder(_searchPhraseParser, _mapper)
                                      .ParseFilters(request.Filter)


### PR DESCRIPTION
## Description
PT-3386: All handlers methods are defined as virtual to allow override.
Non-virtual methods of handlers prohibit overriding handler methods while handler replacement. All found non-virtual handlers methods were declared as virtual.
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-3386
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_1.23.0-pr-185.zip
