### PR TITLE
PT-4102: filter product and category properties by their names

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Schemas/CategoryType.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Schemas/CategoryType.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -96,10 +97,18 @@ namespace VirtoCommerce.XDigitalCatalog.Schemas
 
             });
 
-            ExtendableField<ListGraphType<PropertyType>>("properties", resolve: context =>
+            ExtendableField<ListGraphType<PropertyType>>("properties",
+                arguments: new QueryArguments(new QueryArgument<ListGraphType<StringGraphType>> { Name = "names" }),
+                resolve: context =>
             {
+                var names = context.GetArgument<string[]>("names");
                 var cultureName = context.GetValue<string>("cultureName");
-                return context.Source.Category.Properties.ExpandByValues(cultureName);
+                var result = context.Source.Category.Properties.ExpandByValues(cultureName);
+                if (!names.IsNullOrEmpty())
+                {
+                    result = result.Where(x => names.Contains(x.Name, StringComparer.InvariantCultureIgnoreCase)).ToList();
+                }
+                return result;
             });
 
         }

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Schemas/ProductType.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -238,10 +239,18 @@ namespace VirtoCommerce.XDigitalCatalog.Schemas
                 "prices",
                 resolve: context => context.Source.AllPrices);
 
-            ExtendableField<ListGraphType<PropertyType>>("properties", resolve: context =>
+            ExtendableField<ListGraphType<PropertyType>>("properties",
+                arguments: new QueryArguments(new QueryArgument<ListGraphType<StringGraphType>> { Name = "names" }),
+                resolve: context =>
             {
+                var names = context.GetArgument<string[]>("names");
                 var cultureName = context.GetValue<string>("cultureName");
-                return context.Source.IndexedProduct.Properties.ExpandByValues(cultureName);
+                var result = context.Source.IndexedProduct.Properties.ExpandByValues(cultureName);
+                if (!names.IsNullOrEmpty())
+                {
+                    result = result.Where(x => names.Contains(x.Name, StringComparer.InvariantCultureIgnoreCase)).ToList();
+                }
+                return result;
             });
 
             Field<ListGraphType<AssetType>>(


### PR DESCRIPTION
## Description
Added possibility to filter products and categories properties by their names
![image](https://user-images.githubusercontent.com/7566324/132023299-516541fc-1c13-491f-b1eb-9ece21d0b98c.png)

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-4102
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_1.28.0-pr-202.zip
