### PR TITLE
VDS-2855: Exclude dynamic properties from updateOrganization mutation command fields

### DIFF
--- a/src/XProfile/VirtoCommerce.XProfile/Commands/UpdateOrganizationCommand.cs
+++ b/src/XProfile/VirtoCommerce.XProfile/Commands/UpdateOrganizationCommand.cs
@@ -17,20 +17,19 @@ namespace VirtoCommerce.ExperienceApiModule.XProfile.Commands
         public string Name { get; set; }
         public string MemberType { get; set; }
 
-        public IList<string> PhoneNumbers { get; set; } = new List<string>();
+        public IList<string> PhoneNumbers { get; set; }
         /// <summary>
         /// Returns the email address of the customer.
         /// </summary>
-        public IList<string> Emails { get; set; } = new List<string>();
-        public IList<string> Phones { get; set; } = new List<string>();
-        public IList<string> Groups { get; set; } = new List<string>();
+        public IList<string> Emails { get; set; }
+        public IList<string> Phones { get; set; }
+        public IList<string> Groups { get; set; }
         /// <summary>
         /// User groups such as VIP, Wholesaler etc
         /// </summary>
-        public IList<string> UserGroups { get; set; } = new List<string>();
+        public IList<string> UserGroups { get; set; }
 
-        public IList<Address> Addresses { get; set; } = new List<Address>();
-        public IList<DynamicProperty> DynamicProperties { get; set; } = new List<DynamicProperty>(Enumerable.Empty<DynamicProperty>());
+        public IList<Address> Addresses { get; set; }
         public string UserId { get; set; }
     }
 }


### PR DESCRIPTION
Currently it will remove dynamic properties values on updateOrganization call

## Description

## References
### QA-test:
### Jira-link:
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_1.31.0-pr-210.zip
