### PR TITLE
PT-4850: Fix typecast in the value resolver

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.Core/Extensions/ResolveFieldContextExtensions.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Extensions/ResolveFieldContextExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using GraphQL;
+using GraphQL.Execution;
 using VirtoCommerce.CoreModule.Core.Currency;
 using VirtoCommerce.ExperienceApiModule.Core.Infrastructure;
 using VirtoCommerce.ExperienceApiModule.Core.Queries;
@@ -30,10 +31,20 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Extensions
 
             if (resolveContext.UserContext.TryGetValue(key, out var value))
             {
-                return value is T typedObject ? typedObject : defaultValue;
+                return castValue(value, defaultValue);
             }
 
             return defaultValue;
+
+            static T castValue(object value, T defaultValue)
+            {
+                return value is ArgumentValue argumentValue ? (T)argumentValue.Value : castValueAsTyped(value, defaultValue);
+
+                static T castValueAsTyped(object value, T defaultValue)
+                {
+                    return value is T typedObject ? typedObject : defaultValue;
+                }
+            }
         }
 
         public static T GetValue<T>(this IResolveFieldContext resolveContext, string key)


### PR DESCRIPTION
## Description
Fix typecast in the value resolver, otherwise, some context values become null by mistake.
Example (the request like this returns null reference exception instead of result): 
```

query {
  product(storeId: "TestStore", currencyCode: "USD", id: "D994A14A-DB1D-4270-81CB-2D8F875A6CE5") {
    name
    id
    code
    slug
    outline
    imgSrc
    images {
      url
    }
    description {
      content
      id
      languageCode
      reviewType
    }
    descriptions {
      content
      id
      languageCode
      reviewType
    }
    properties {
      name
      value
      type
    }
    variations {
      id
      code
      properties {
        name
        value
        type
      }
      availabilityData {
        isActive
        isAvailable
        isBuyable
        isInStock
        availableQuantity
      }
      price {
        actual {
          amount
          formattedAmount
        }
        discountAmount {
          amount
          formattedAmount
        }
        sale {
          amount
          formattedAmount
        }
        list {
          amount
          formattedAmount
        }
      }
    }
    availabilityData {
      isActive
      isAvailable
      isBuyable
      isInStock
      availableQuantity
    }
    price {
      actual {
        amount
        formattedAmount
      }
      discountAmount {
        amount
        formattedAmount
      }
      sale {
        amount
        formattedAmount
      }
      list {
        amount
        formattedAmount
      }
    }
  }
}
```

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-4850
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_1.37.0-pr-228.zip
