### PR TITLE
PT-4397: Any dynamic property type should accept "cultureName" field as well as "locale" field

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/InputDynamicPropertyValueType.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/InputDynamicPropertyValueType.cs
@@ -10,7 +10,8 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Schemas
         {
             Field(x => x.Name).Description("Dynamic property name");
             Field<StringGraphType>(nameof(DynamicPropertyObjectValue.Value), "Dynamic property value. ID must be passed for dictionary item");
-            Field(x => x.Locale, true).Description("Language (\"en-US\") for multilingual property");
+            Field<StringGraphType>("locale", resolve: x => x.Source.Locale, description: "Language (\"en-US\") for multilingual property", deprecationReason: "Deprecated. Use cultureName field. Will be removed in v. 1.50+");
+            Field("cultureName", x => x.Locale, true).Description("Culture name (\"en-US\") for multilingual property");
         }
     }
 }


### PR DESCRIPTION
## Description
Any dynamic property type should accept "cultureName" field as well as "locale" field
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-4397
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_1.39.0-pr-236.zip
