### PR TITLE
PT-4621: Softly delete the cart after an order created based on

### DIFF
--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/CreateOrderFromCartCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/CreateOrderFromCartCommandHandler.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -23,7 +24,9 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
         {
             var cart = await _cartService.GetByIdAsync(request.CartId);
             var result = await _customerOrderAggregateRepository.CreateOrderFromCart(cart);
-
+            await _cartService.DeleteAsync(new List<string> { request.CartId }, true);
+            // Remark: There is potential bug, because there is no transaction thru two actions above. If a cart deletion fails, the order remains. That causes data inconsistency.
+            // Unfortunately, current architecture does not allow us to support such scenarios in a transactional manner.
             return result;
         }
     }

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/CreateOrderFromCartCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/CreateOrderFromCartCommandHandler.cs
@@ -24,7 +24,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
         {
             var cart = await _cartService.GetByIdAsync(request.CartId);
             var result = await _customerOrderAggregateRepository.CreateOrderFromCart(cart);
-            await _cartService.DeleteAsync(new List<string> { request.CartId }, true);
+            await _cartService.DeleteAsync(new List<string> { request.CartId }, softDelete: true);
             // Remark: There is potential bug, because there is no transaction thru two actions above. If a cart deletion fails, the order remains. That causes data inconsistency.
             // Unfortunately, current architecture does not allow us to support such scenarios in a transactional manner.
             return result;

--- a/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/Handlers/CreateOrderFromCartCommandHandlerTests.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/Handlers/CreateOrderFromCartCommandHandlerTests.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using VirtoCommerce.CartModule.Core.Model;
+using VirtoCommerce.CartModule.Data.Services;
+using VirtoCommerce.ExperienceApiModule.XOrder;
+using VirtoCommerce.ExperienceApiModule.XOrder.Commands;
+using VirtoCommerce.XPurchase.Tests.Helpers;
+using Xunit;
+
+namespace VirtoCommerce.XPurchase.Tests.Handlers
+{
+    public class CreateOrderFromCartCommandHandlerTests : XPurchaseMoqHelper
+    {
+
+        /// <summary>
+        /// To test if soft cart delete is calling in the create order routine
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task Handle_CreateOrder_EnsureCartDeleted()
+        {
+            // Arrange
+            var cartService = new Mock<ShoppingCartService>(null, null, null, null);
+            var deleteCalled = false;
+            cartService.Setup(x => x.GetByIdAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new ShoppingCart());
+            cartService.Setup(x => x.DeleteAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<bool>()))
+                .Returns(() =>
+                        {
+                            deleteCalled = true;
+                            return Task.CompletedTask;
+                        });
+
+            var customerAggrRep = new Mock<ICustomerOrderAggregateRepository>();
+            customerAggrRep.Setup(x => x.CreateOrderFromCart(It.IsAny<ShoppingCart>()))
+                .ReturnsAsync(new CustomerOrderAggregate(null, null));
+
+            // Take action
+            var handler = new CreateOrderFromCartCommandHandler(cartService.Object, customerAggrRep.Object);
+            await handler.Handle(new CreateOrderFromCartCommand(""), CancellationToken.None);
+
+            // Assert
+            deleteCalled.Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
## Description
Softly delete the cart after an order created based on
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-4621
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_1.45.0-pr-243.zip
