### PR TITLE
DL-60: remove usage of obsolete IPricingService

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Middlewares/EvalProductsPricesMiddleware.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Middlewares/EvalProductsPricesMiddleware.cs
@@ -17,18 +17,18 @@ namespace VirtoCommerce.XDigitalCatalog.Middlewares
     public class EvalProductsPricesMiddleware : IAsyncMiddleware<SearchProductResponse>
     {
         private readonly IMapper _mapper;
-        private readonly IPricingEvaluatorService _pricingService;
+        private readonly IPricingEvaluatorService _pricingEvaluatorService;
         private readonly IGenericPipelineLauncher _pipeline;
         private readonly IStoreService _storeService;
 
         public EvalProductsPricesMiddleware(
             IMapper mapper,
-            IPricingEvaluatorService pricingService,
+            IPricingEvaluatorService pricingEvaluatorService,
             IGenericPipelineLauncher pipeline,
             IStoreService storeService)
         {
             _mapper = mapper;
-            _pricingService = pricingService;
+            _pricingEvaluatorService = pricingEvaluatorService;
             _pipeline = pipeline;
             _storeService = storeService;
         }
@@ -81,7 +81,7 @@ namespace VirtoCommerce.XDigitalCatalog.Middlewares
                     await _pipeline.Execute(evalContext);
 
                     evalContext.ProductIds = productsWithoutPrices.Select(x => x.Id).ToArray();
-                    var prices = await _pricingService.EvaluateProductPricesAsync(evalContext);
+                    var prices = await _pricingEvaluatorService.EvaluateProductPricesAsync(evalContext);
 
                     foreach (var product in productsWithoutPrices)
                     {

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Middlewares/EvalProductsPricesMiddleware.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Middlewares/EvalProductsPricesMiddleware.cs
@@ -17,13 +17,13 @@ namespace VirtoCommerce.XDigitalCatalog.Middlewares
     public class EvalProductsPricesMiddleware : IAsyncMiddleware<SearchProductResponse>
     {
         private readonly IMapper _mapper;
-        private readonly IPricingService _pricingService;
+        private readonly IPricingEvaluatorService _pricingService;
         private readonly IGenericPipelineLauncher _pipeline;
         private readonly IStoreService _storeService;
 
         public EvalProductsPricesMiddleware(
             IMapper mapper,
-            IPricingService pricingService,
+            IPricingEvaluatorService pricingService,
             IGenericPipelineLauncher pipeline,
             IStoreService storeService)
         {

--- a/src/VirtoCommerce.ExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ExperienceApiModule.Web/module.manifest
@@ -1,1 +1,48 @@
-﻿<?xml version="1.0" encoding="utf-8"?><module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><id>VirtoCommerce.ExperienceApi</id><version>3.208.0</version><version-tag /><platformVersion>3.200.0</platformVersion><title>Commerce experience API module</title><description /><authors><author>Eugeny Tatarincev</author><author>Yan Brovkin</author><author>Fillip Kuksov</author><author>Egidijus Mažeika</author><author>Andrei Kostyrin</author><author>Dmitri Pushnitsa</author><author>Alexandr Andreev</author><author>Andrey Kozlov</author><author>Konstantin Savosteev</author></authors><owners><owner>Virto Commerce</owner></owners><projectUrl>https://virtocommerce.com</projectUrl><iconUrl>Modules/$(VirtoCommerce.ExperienceApi)/Content/logoVC.png</iconUrl><requireLicenseAcceptance>false</requireLicenseAcceptance><releaseNotes /><copyright>Copyright © 2011-2022 Virto Commerce. All rights reserved</copyright><tags>security core</tags><assemblyFile>VirtoCommerce.ExperienceApiModule.Web.dll</assemblyFile><moduleType>VirtoCommerce.ExperienceApiModule.Web.Module, VirtoCommerce.ExperienceApiModule.Web</moduleType><dependencies><dependency id="VirtoCommerce.Core" version="3.200.0" /><dependency id="VirtoCommerce.Cart" version="3.200.0" /><dependency id="VirtoCommerce.Marketing" version="3.200.0" /><dependency id="VirtoCommerce.Inventory" version="3.200.0" /><dependency id="VirtoCommerce.Payment" version="3.200.0" /><dependency id="VirtoCommerce.Shipping" version="3.200.0" /><dependency id="VirtoCommerce.Customer" version="3.200.0" /><dependency id="VirtoCommerce.Orders" version="3.200.0" /><dependency id="VirtoCommerce.Store" version="3.201.0" /><dependency id="VirtoCommerce.Catalog" version="3.200.0" /><dependency id="VirtoCommerce.Pricing" version="3.201.0" /></dependencies><incompatibilities /><groups><group>commerce</group></groups><useFullTypeNameInSwagger>false</useFullTypeNameInSwagger></module>
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <id>VirtoCommerce.ExperienceApi</id>
+   <version>3.208.0</version>
+   <version-tag />
+   <platformVersion>3.200.0</platformVersion>
+   <title>Commerce experience API module</title>
+   <description />
+   <authors>
+      <author>Eugeny Tatarincev</author>
+      <author>Yan Brovkin</author>
+      <author>Fillip Kuksov</author>
+      <author>Egidijus Mažeika</author>
+      <author>Andrei Kostyrin</author>
+      <author>Dmitri Pushnitsa</author>
+      <author>Alexandr Andreev</author>
+      <author>Andrey Kozlov</author>
+      <author>Konstantin Savosteev</author>
+   </authors>
+   <owners>
+      <owner>Virto Commerce</owner>
+   </owners>
+   <projectUrl>https://virtocommerce.com</projectUrl>
+   <iconUrl>Modules/$(VirtoCommerce.ExperienceApi)/Content/logoVC.png</iconUrl>
+   <requireLicenseAcceptance>false</requireLicenseAcceptance>
+   <releaseNotes />
+   <copyright>Copyright © 2011-2022 Virto Commerce. All rights reserved</copyright>
+   <tags>security core</tags>
+   <assemblyFile>VirtoCommerce.ExperienceApiModule.Web.dll</assemblyFile>
+   <moduleType>VirtoCommerce.ExperienceApiModule.Web.Module, VirtoCommerce.ExperienceApiModule.Web</moduleType>
+   <dependencies>
+      <dependency id="VirtoCommerce.Core" version="3.200.0" />
+      <dependency id="VirtoCommerce.Cart" version="3.200.0" />
+      <dependency id="VirtoCommerce.Marketing" version="3.200.0" />
+      <dependency id="VirtoCommerce.Inventory" version="3.200.0" />
+      <dependency id="VirtoCommerce.Payment" version="3.200.0" />
+      <dependency id="VirtoCommerce.Shipping" version="3.200.0" />
+      <dependency id="VirtoCommerce.Customer" version="3.200.0" />
+      <dependency id="VirtoCommerce.Orders" version="3.200.0" />
+      <dependency id="VirtoCommerce.Store" version="3.201.0" />
+      <dependency id="VirtoCommerce.Catalog" version="3.200.0" />
+   </dependencies>
+   <incompatibilities />
+   <groups>
+      <group>commerce</group>
+   </groups>
+   <useFullTypeNameInSwagger>false</useFullTypeNameInSwagger>
+</module>

--- a/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/Services/CartProductServiceFake.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/Services/CartProductServiceFake.cs
@@ -13,7 +13,7 @@ namespace VirtoCommerce.XPurchase.Tests.Services
     {
         public CartProductServiceFake(IItemService productService
             , IInventorySearchService inventoryService
-            , IPricingService pricingService
+            , IPricingEvaluatorService pricingService
             , IMapper mapper) : base(productService, inventoryService, pricingService, mapper)
         {
         }

--- a/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/Services/CartProductServiceFake.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/Services/CartProductServiceFake.cs
@@ -13,8 +13,8 @@ namespace VirtoCommerce.XPurchase.Tests.Services
     {
         public CartProductServiceFake(IItemService productService
             , IInventorySearchService inventoryService
-            , IPricingEvaluatorService pricingService
-            , IMapper mapper) : base(productService, inventoryService, pricingService, mapper)
+            , IPricingEvaluatorService pricingEvaluatorService
+            , IMapper mapper) : base(productService, inventoryService, pricingEvaluatorService, mapper)
         {
         }
 

--- a/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/Services/CartProductServiceTests.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/Services/CartProductServiceTests.cs
@@ -16,7 +16,7 @@ namespace VirtoCommerce.XPurchase.Tests.Services
     {
         private readonly Mock<IItemService> _productService;
         private readonly Mock<IInventorySearchService> _inventorySearchService;
-        private readonly Mock<IPricingService> _pricingService;
+        private readonly Mock<IPricingEvaluatorService> _pricingService;
         private readonly Mock<IMapper> _mapper;
         private readonly CartProductServiceFake _service;
 
@@ -24,7 +24,7 @@ namespace VirtoCommerce.XPurchase.Tests.Services
         {
             _productService = new Mock<IItemService>();
             _inventorySearchService = new Mock<IInventorySearchService>();
-            _pricingService = new Mock<IPricingService>();
+            _pricingService = new Mock<IPricingEvaluatorService>();
             _mapper = new Mock<IMapper>();
             _service = new CartProductServiceFake(_productService.Object, _inventorySearchService.Object, _pricingService.Object, _mapper.Object);
         }

--- a/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/Services/CartProductServiceTests.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/Services/CartProductServiceTests.cs
@@ -16,7 +16,7 @@ namespace VirtoCommerce.XPurchase.Tests.Services
     {
         private readonly Mock<IItemService> _productService;
         private readonly Mock<IInventorySearchService> _inventorySearchService;
-        private readonly Mock<IPricingEvaluatorService> _pricingService;
+        private readonly Mock<IPricingEvaluatorService> _pricingEvaluatorService;
         private readonly Mock<IMapper> _mapper;
         private readonly CartProductServiceFake _service;
 
@@ -24,9 +24,9 @@ namespace VirtoCommerce.XPurchase.Tests.Services
         {
             _productService = new Mock<IItemService>();
             _inventorySearchService = new Mock<IInventorySearchService>();
-            _pricingService = new Mock<IPricingEvaluatorService>();
+            _pricingEvaluatorService = new Mock<IPricingEvaluatorService>();
             _mapper = new Mock<IMapper>();
-            _service = new CartProductServiceFake(_productService.Object, _inventorySearchService.Object, _pricingService.Object, _mapper.Object);
+            _service = new CartProductServiceFake(_productService.Object, _inventorySearchService.Object, _pricingEvaluatorService.Object, _mapper.Object);
         }
 
         [Fact]

--- a/src/XPurchase/VirtoCommerce.XPurchase/Services/CartProductService.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Services/CartProductService.cs
@@ -16,7 +16,7 @@ namespace VirtoCommerce.XPurchase.Services
     {
         private readonly IItemService _productService;
         private readonly IInventorySearchService _inventorySearchService;
-        private readonly IPricingEvaluatorService _pricingService;
+        private readonly IPricingEvaluatorService _pricingEvaluatorService;
         private readonly IMapper _mapper;
 
         /// <summary>
@@ -29,11 +29,11 @@ namespace VirtoCommerce.XPurchase.Services
         /// </summary>
         protected virtual int DefaultPageSize => 50;
 
-        public CartProductService(IItemService productService, IInventorySearchService inventoryService, IPricingEvaluatorService pricingService, IMapper mapper)
+        public CartProductService(IItemService productService, IInventorySearchService inventoryService, IPricingEvaluatorService pricingEvaluatorService, IMapper mapper)
         {
             _productService = productService;
             _inventorySearchService = inventoryService;
-            _pricingService = pricingService;
+            _pricingEvaluatorService = pricingEvaluatorService;
             _mapper = mapper;
         }
 
@@ -143,7 +143,7 @@ namespace VirtoCommerce.XPurchase.Services
             var pricesEvalContext = _mapper.Map<PriceEvaluationContext>(aggregate);
             pricesEvalContext.ProductIds = products.Select(x => x.Id).ToArray();
 
-            var evalPricesTask = await _pricingService.EvaluateProductPricesAsync(pricesEvalContext);
+            var evalPricesTask = await _pricingEvaluatorService.EvaluateProductPricesAsync(pricesEvalContext);
 
             foreach (var cartProduct in products)
             {

--- a/src/XPurchase/VirtoCommerce.XPurchase/Services/CartProductService.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Services/CartProductService.cs
@@ -16,7 +16,7 @@ namespace VirtoCommerce.XPurchase.Services
     {
         private readonly IItemService _productService;
         private readonly IInventorySearchService _inventorySearchService;
-        private readonly IPricingService _pricingService;
+        private readonly IPricingEvaluatorService _pricingService;
         private readonly IMapper _mapper;
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace VirtoCommerce.XPurchase.Services
         /// </summary>
         protected virtual int DefaultPageSize => 50;
 
-        public CartProductService(IItemService productService, IInventorySearchService inventoryService, IPricingService pricingService, IMapper mapper)
+        public CartProductService(IItemService productService, IInventorySearchService inventoryService, IPricingEvaluatorService pricingService, IMapper mapper)
         {
             _productService = productService;
             _inventorySearchService = inventoryService;


### PR DESCRIPTION
## Description
DL-60 inspired. Use IPricingEvaluatorService instead of obsolete and too complex IPricingService.
## References
### QA-test:
### Jira-link:



https://virtocommerce.atlassian.net/browse/DL-60
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.208.0-pr-297.zip
