### PR TITLE
PT-7542, PT-7548: add initializePayment mutation, authorizePayment mutation

### DIFF
--- a/docs/x-purchase-order-reference.md
+++ b/docs/x-purchase-order-reference.md
@@ -27,6 +27,8 @@ X-Purchase-Order provides high performance API for order data.
 |6 |[updateOrderItemDynamicProperties](#updateOrderItemDynamicProperties)|`!lineItemId` `!dynamicProperties`|Updates dynamic properties in order items.|
 |7 |[updateOrderShipmentDynamicProperties](#updateOrderShipmentDynamicProperties)|`!shipmentId` `!dynamicProperties`|Updates dynamic properties in order shipment.|
 |8 |[updateOrderPaymentDynamicProperties](#updateOrderPaymentDynamicProperties)|`!paymentId` `!dynamicProperties`|Updates dynamic properties in order payment.|
+|9 |[initializePayment](#initializePayment)|`orderId` `!paymentId`|Initiates payment processing
+|10|[authorizePayment](#authorizePayment)|`orderId` `!paymentId` `parameters { key value }`|Finalizes first step of the payment processing
 
 > [!NOTE]
 > In arguments column we show additional arguments. if they are marked with an exclamation mark, they are required.
@@ -527,4 +529,72 @@ mutation ($command: InputUpdateOrderPaymentDynamicPropertiesType!)
   	]
   }
 }
+```
+
+### initializePayment
+
+This mutation initiates payment processing
+
+#### 
+
+```
+mutation ($command: InputInitializePaymentType!)
+{
+    initializePayment(command: $command)
+    {
+        isSuccess
+        errorMessage
+        storeId
+        paymentId
+        orderId
+        orderNumber
+        paymentMethodCode
+        paymentActionType
+        actionRedirectUrl
+        publicParameters {
+          key
+          value
+        }
+      }
+}
+```
+
+#### Variables
+
+```
+"command": {
+    "orderId": "d548c750-5a74-4e54-b72b-f5209f44caa6",
+    "paymentId": "0859f1e8-16e8-4924-808b-47e03560085d"
+  }
+```
+
+### authorizePayment
+
+This mutation finalizes first step of the payment processing
+
+#### Query
+
+mutation ($command: InputAuthorizePaymentType!) {
+  authorizePayment(command: $command) {
+    isSuccess
+    errorMessage
+  }
+}
+
+#### Variables
+
+```
+"command": {
+    "orderId": "d548c750-5a74-4e54-b72b-f5209f44caa6",
+    "paymentId": "0859f1e8-16e8-4924-808b-47e03560085d",
+    "parameters": [
+      {
+        key: "key1",
+        value: "value1"
+      },
+      {
+        key: "key2",
+        value: "value2"
+      }
+  }
 ```

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Models/KeyValuePair.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Models/KeyValuePair.cs
@@ -1,0 +1,8 @@
+namespace VirtoCommerce.ExperienceApiModule.Core.Models
+{
+    public class KeyValuePair
+    {
+        public string Key { get; set; }
+        public string Value { get; set; }
+    }
+}

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/InputKeyValueType.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/InputKeyValueType.cs
@@ -1,0 +1,14 @@
+using GraphQL.Types;
+using VirtoCommerce.ExperienceApiModule.Core.Models;
+
+namespace VirtoCommerce.ExperienceApiModule.Core.Schemas
+{
+    public class InputKeyValueType : InputObjectGraphType<KeyValuePair>
+    {
+        public InputKeyValueType()
+        {
+            Field(x => x.Key, nullable: false).Description("Dictionary key");
+            Field(x => x.Value, nullable: true).Description("Dictionary value");
+        }
+    }
+}

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/KeyValueType.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/KeyValueType.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using GraphQL.Types;
+
+namespace VirtoCommerce.ExperienceApiModule.Core.Schemas
+{
+    public class KeyValueType : ObjectGraphType<KeyValuePair<string, string>>
+    {
+        public KeyValueType()
+        {
+            Field(x => x.Key, nullable: false).Description("Dictionary key");
+            Field(x => x.Value, nullable: true).Description("Dictionary value");
+        }
+    }
+}

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/KeyValueType.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/KeyValueType.cs
@@ -1,9 +1,9 @@
-using System.Collections.Generic;
 using GraphQL.Types;
+using VirtoCommerce.ExperienceApiModule.Core.Models;
 
 namespace VirtoCommerce.ExperienceApiModule.Core.Schemas
 {
-    public class KeyValueType : ObjectGraphType<KeyValuePair<string, string>>
+    public class KeyValueType : ObjectGraphType<KeyValuePair>
     {
         public KeyValueType()
         {

--- a/src/VirtoCommerce.ExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ExperienceApiModule.Web/module.manifest
@@ -1,1 +1,48 @@
-﻿<?xml version="1.0" encoding="utf-8"?><module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><id>VirtoCommerce.ExperienceApi</id><version>3.213.0</version><version-tag /><platformVersion>3.207.0</platformVersion><title>Commerce experience API module</title><description /><authors><author>Eugeny Tatarincev</author><author>Yan Brovkin</author><author>Fillip Kuksov</author><author>Egidijus Mažeika</author><author>Andrei Kostyrin</author><author>Dmitri Pushnitsa</author><author>Alexandr Andreev</author><author>Andrey Kozlov</author><author>Konstantin Savosteev</author></authors><owners><owner>Virto Commerce</owner></owners><projectUrl>https://virtocommerce.com</projectUrl><iconUrl>Modules/$(VirtoCommerce.ExperienceApi)/Content/logoVC.png</iconUrl><requireLicenseAcceptance>false</requireLicenseAcceptance><releaseNotes /><copyright>Copyright © 2011-2022 Virto Commerce. All rights reserved</copyright><tags>security core</tags><assemblyFile>VirtoCommerce.ExperienceApiModule.Web.dll</assemblyFile><moduleType>VirtoCommerce.ExperienceApiModule.Web.Module, VirtoCommerce.ExperienceApiModule.Web</moduleType><dependencies><dependency id="VirtoCommerce.Core" version="3.200.0" /><dependency id="VirtoCommerce.Cart" version="3.200.0" /><dependency id="VirtoCommerce.Marketing" version="3.200.0" /><dependency id="VirtoCommerce.Inventory" version="3.200.0" /><dependency id="VirtoCommerce.Payment" version="3.200.0" /><dependency id="VirtoCommerce.Shipping" version="3.200.0" /><dependency id="VirtoCommerce.Customer" version="3.200.0" /><dependency id="VirtoCommerce.Orders" version="3.200.0" /><dependency id="VirtoCommerce.Store" version="3.201.0" /><dependency id="VirtoCommerce.Catalog" version="3.213.0" /></dependencies><incompatibilities /><groups><group>commerce</group></groups><useFullTypeNameInSwagger>false</useFullTypeNameInSwagger></module>
+<?xml version="1.0" encoding="utf-8"?>
+<module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <id>VirtoCommerce.ExperienceApi</id>
+    <version>3.213.0</version>
+    <version-tag />
+    <platformVersion>3.207.0</platformVersion>
+    <title>Commerce experience API module</title>
+    <description />
+    <authors>
+        <author>Eugeny Tatarincev</author>
+        <author>Yan Brovkin</author>
+        <author>Fillip Kuksov</author>
+        <author>Egidijus Mažeika</author>
+        <author>Andrei Kostyrin</author>
+        <author>Dmitri Pushnitsa</author>
+        <author>Alexandr Andreev</author>
+        <author>Andrey Kozlov</author>
+        <author>Konstantin Savosteev</author>
+    </authors>
+    <owners>
+        <owner>Virto Commerce</owner>
+    </owners>
+    <projectUrl>https://virtocommerce.com</projectUrl>
+    <iconUrl>Modules/$(VirtoCommerce.ExperienceApi)/Content/logoVC.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes />
+    <copyright>Copyright © 2011-2022 Virto Commerce. All rights reserved</copyright>
+    <tags>security core</tags>
+    <assemblyFile>VirtoCommerce.ExperienceApiModule.Web.dll</assemblyFile>
+    <moduleType>VirtoCommerce.ExperienceApiModule.Web.Module, VirtoCommerce.ExperienceApiModule.Web</moduleType>
+    <dependencies>
+        <dependency id="VirtoCommerce.Core" version="3.200.0" />
+        <dependency id="VirtoCommerce.Cart" version="3.200.0" />
+        <dependency id="VirtoCommerce.Marketing" version="3.200.0" />
+        <dependency id="VirtoCommerce.Inventory" version="3.200.0" />
+        <dependency id="VirtoCommerce.Payment" version="3.204.0" />
+        <dependency id="VirtoCommerce.Shipping" version="3.200.0" />
+        <dependency id="VirtoCommerce.Customer" version="3.200.0" />
+        <dependency id="VirtoCommerce.Orders" version="3.200.0" />
+        <dependency id="VirtoCommerce.Store" version="3.201.0" />
+        <dependency id="VirtoCommerce.Catalog" version="3.213.0" />
+    </dependencies>
+    <incompatibilities />
+    <groups>
+        <group>commerce</group>
+    </groups>
+    <useFullTypeNameInSwagger>false</useFullTypeNameInSwagger>
+</module>

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/AuthorizePaymentCommand.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/AuthorizePaymentCommand.cs
@@ -1,0 +1,17 @@
+using VirtoCommerce.ExperienceApiModule.Core.Infrastructure;
+using VirtoCommerce.ExperienceApiModule.Core.Models;
+using VirtoCommerce.ExperienceApiModule.XOrder.Models;
+
+namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
+{
+    public class AuthorizePaymentCommand : ICommand<AuthorizePaymentResult>
+    {
+        public string OrderId { get; set; }
+
+        public string PaymentId { get; set; }
+
+        //public string PaymentMethodCode { get; set; }
+
+        public KeyValuePair[] Parameters { get; set; }
+    }
+}

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/AuthorizePaymentCommand.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/AuthorizePaymentCommand.cs
@@ -4,14 +4,8 @@ using VirtoCommerce.ExperienceApiModule.XOrder.Models;
 
 namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
 {
-    public class AuthorizePaymentCommand : ICommand<AuthorizePaymentResult>
+    public class AuthorizePaymentCommand : PaymentCommandBase, ICommand<AuthorizePaymentResult>
     {
-        public string OrderId { get; set; }
-
-        public string PaymentId { get; set; }
-
-        //public string PaymentMethodCode { get; set; }
-
         public KeyValuePair[] Parameters { get; set; }
     }
 }

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/AuthorizePaymentCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/AuthorizePaymentCommandHandler.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using VirtoCommerce.ExperienceApiModule.Core.Models;
+using VirtoCommerce.ExperienceApiModule.XOrder.Models;
+using VirtoCommerce.OrdersModule.Core.Model;
+using VirtoCommerce.PaymentModule.Core.Model;
+using VirtoCommerce.PaymentModule.Model.Requests;
+using VirtoCommerce.Platform.Core.GenericCrud;
+using VirtoCommerce.StoreModule.Core.Model;
+
+namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
+{
+    public class AuthorizePaymentCommandHandler : IRequestHandler<AuthorizePaymentCommand, AuthorizePaymentResult>
+    {
+        private readonly ICrudService<CustomerOrder> _customerOrderService;
+        private readonly ICrudService<PaymentIn> _paymentService;
+        private readonly ICrudService<Store> _storeService;
+
+        public AuthorizePaymentCommandHandler(
+            ICrudService<CustomerOrder> customerOrderService,
+            ICrudService<PaymentIn> paymentService,
+            ICrudService<Store> storeService)
+        {
+            _customerOrderService = customerOrderService;
+            _paymentService = paymentService;
+            _storeService = storeService;
+        }
+
+        public async Task<AuthorizePaymentResult> Handle(AuthorizePaymentCommand request, CancellationToken cancellationToken)
+        {
+            var customerOrder = default(CustomerOrder);
+            var payment = default(PaymentIn);
+
+            if (!string.IsNullOrEmpty(request.OrderId))
+            {
+                customerOrder = await _customerOrderService.GetByIdAsync(request.OrderId, CustomerOrderResponseGroup.Full.ToString());
+                payment = customerOrder?.InPayments?.FirstOrDefault(x => x.Id == request.PaymentId);
+            }
+            else if (!string.IsNullOrEmpty(request.PaymentId))
+            {
+                payment = await _paymentService.GetByIdAsync(request.PaymentId);
+                customerOrder = await _customerOrderService.GetByIdAsync(payment?.OrderId, CustomerOrderResponseGroup.Full.ToString());
+
+                // take payment from order since Order payment contains instanced PaymentMethod (payment taken from service doesn't)
+                payment = customerOrder?.InPayments?.FirstOrDefault(x => x.Id == request.PaymentId);
+            }
+
+            if (customerOrder == null)
+            {
+                return ErrorResult($"Cannot find order with ID {request.OrderId}");
+            }
+
+            if (payment == null)
+            {
+                return ErrorResult($"Cannot find payment with ID {request.PaymentId}");
+            }
+
+            if (payment.PaymentStatus == PaymentStatus.Paid)
+            {
+                return ErrorResult($"Document {payment.Number} is already paid");
+            }
+
+            var store = await _storeService.GetByIdAsync(customerOrder.StoreId, StoreResponseGroup.StoreInfo.ToString());
+            if (store == null)
+            {
+                return ErrorResult($"Cannot find store with ID {customerOrder.StoreId}");
+            }
+
+            var parameters = GetParameters(request);
+
+            var validateResult = payment.PaymentMethod.ValidatePostProcessRequest(parameters);
+            if (!validateResult.IsSuccess)
+            {
+                return ErrorResult(validateResult.ErrorMessage);
+            }
+
+            var postProcessPaymentRequest = new PostProcessPaymentRequest
+            {
+                OrderId = customerOrder.Id,
+                Order = customerOrder,
+                PaymentId = payment.Id,
+                Payment = payment,
+                StoreId = customerOrder.StoreId,
+                Store = store,
+                OuterId = validateResult.OuterId,
+                Parameters = parameters
+            };
+
+            var result = await AuthorizePaymentAsync(postProcessPaymentRequest);
+
+            if (result.IsSuccess)
+            {
+                await _customerOrderService.SaveChangesAsync(new[] { customerOrder });
+            }
+
+            return result;
+        }
+
+        protected virtual Task<AuthorizePaymentResult> AuthorizePaymentAsync(PostProcessPaymentRequest request)
+        {
+            var payment = request.Payment as PaymentIn;
+            var order = request.Order as CustomerOrder;
+
+            var processPaymentRequestResult = payment.PaymentMethod.PostProcessPayment(request);
+
+            var result = new AuthorizePaymentResult
+            {
+                IsSuccess = processPaymentRequestResult.IsSuccess,
+                ErrorMessage = processPaymentRequestResult.ErrorMessage
+            };
+
+            return Task.FromResult(result);
+        }
+
+
+        private static NameValueCollection GetParameters(AuthorizePaymentCommand request)
+        {
+            var parameters = new NameValueCollection();
+            foreach (var param in request?.Parameters ?? Array.Empty<KeyValuePair>())
+            {
+                parameters.Add(param.Key, param.Value);
+            }
+
+            return parameters;
+        }
+
+        private static AuthorizePaymentResult ErrorResult(string error)
+        {
+            return new AuthorizePaymentResult
+            {
+                IsSuccess = false,
+                ErrorMessage = error,
+            };
+        }
+    }
+}

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/AuthorizePaymentCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/AuthorizePaymentCommandHandler.cs
@@ -1,113 +1,14 @@
-using System;
-using System.Collections.Specialized;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
-using VirtoCommerce.ExperienceApiModule.Core.Models;
 using VirtoCommerce.ExperienceApiModule.XOrder.Models;
 using VirtoCommerce.OrdersModule.Core.Model;
-using VirtoCommerce.PaymentModule.Core.Model;
 using VirtoCommerce.PaymentModule.Model.Requests;
 using VirtoCommerce.Platform.Core.GenericCrud;
 using VirtoCommerce.StoreModule.Core.Model;
 
 namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
 {
-    public abstract class PaymentCommandHandlerBase
-    {
-        private readonly ICrudService<CustomerOrder> _customerOrderService;
-        private readonly ICrudService<PaymentIn> _paymentService;
-        private readonly ICrudService<Store> _storeService;
-
-        public PaymentCommandHandlerBase(
-            ICrudService<CustomerOrder> customerOrderService,
-            ICrudService<PaymentIn> paymentService,
-            ICrudService<Store> storeService)
-        {
-            _customerOrderService = customerOrderService;
-            _paymentService = paymentService;
-            _storeService = storeService;
-        }
-
-        protected async Task<PaymentInfo> GetPaymentInfo(PaymentCommandBase command)
-        {
-            var result = new PaymentInfo();
-
-            if (!string.IsNullOrEmpty(command.OrderId))
-            {
-                result.CustomerOrder = await _customerOrderService.GetByIdAsync(command.OrderId, CustomerOrderResponseGroup.Full.ToString());
-                result.Payment = result.CustomerOrder?.InPayments?.FirstOrDefault(x => x.Id == command.PaymentId);
-            }
-            else if (!string.IsNullOrEmpty(command.PaymentId))
-            {
-                result.Payment = await _paymentService.GetByIdAsync(command.PaymentId);
-                result.CustomerOrder = await _customerOrderService.GetByIdAsync(result.Payment?.OrderId, CustomerOrderResponseGroup.Full.ToString());
-
-                // take payment from order since Order payment contains instanced PaymentMethod (payment taken from service doesn't)
-                result.Payment = result.CustomerOrder?.InPayments?.FirstOrDefault(x => x.Id == command.PaymentId);
-            }
-
-            result.Store = await _storeService.GetByIdAsync(result.CustomerOrder?.StoreId, StoreResponseGroup.StoreInfo.ToString());
-
-            return result;
-        }
-
-        protected string ValidateRequest(PaymentInfo payment, PaymentCommandBase command)
-        {
-            if (payment.CustomerOrder == null)
-            {
-                return $"Cannot find order with ID {command.OrderId}";
-            }
-
-            if (payment.Payment == null)
-            {
-                return $"Cannot find payment with ID {command.PaymentId}";
-            }
-
-            if (payment.Payment.PaymentStatus == PaymentStatus.Paid)
-            {
-                return $"Document {payment.Payment.Number} is already paid";
-            }
-
-            if (payment.Store == null)
-            {
-                return $"Cannot find store with ID {payment.CustomerOrder?.StoreId}";
-            }
-
-            return null;
-        }
-
-        protected static NameValueCollection GetParameters(AuthorizePaymentCommand request)
-        {
-            var parameters = new NameValueCollection();
-            foreach (var param in request?.Parameters ?? Array.Empty<KeyValuePair>())
-            {
-                parameters.Add(param.Key, param.Value);
-            }
-
-            return parameters;
-        }
-
-        protected T ErrorResult<T>(string error) where T : PaymentResult, new()
-        {
-            return new T
-            {
-                IsSuccess = false,
-                ErrorMessage = error,
-            };
-        }
-
-        public class PaymentInfo
-        {
-            public CustomerOrder CustomerOrder { get; set; }
-
-            public PaymentIn Payment { get; set; }
-
-            public Store Store { get; set; }
-        }
-    }
-
     public class AuthorizePaymentCommandHandler : PaymentCommandHandlerBase, IRequestHandler<AuthorizePaymentCommand, AuthorizePaymentResult>
     {
         private readonly ICrudService<CustomerOrder> _customerOrderService;

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/AuthorizePaymentCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/AuthorizePaymentCommandHandler.cs
@@ -56,16 +56,18 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
 
             var processPaymentRequestResult = paymentInfo.Payment.PaymentMethod.PostProcessPayment(postProcessPaymentRequest);
 
+            if (processPaymentRequestResult.IsSuccess)
+            {
+                paymentInfo.Payment.Status = processPaymentRequestResult.NewPaymentStatus.ToString();
+
+                await _customerOrderService.SaveChangesAsync(new[] { paymentInfo.CustomerOrder });
+            }
+
             var result = new AuthorizePaymentResult
             {
                 IsSuccess = processPaymentRequestResult.IsSuccess,
                 ErrorMessage = processPaymentRequestResult.ErrorMessage,
             };
-
-            if (result.IsSuccess)
-            {
-                await _customerOrderService.SaveChangesAsync(new[] { paymentInfo.CustomerOrder });
-            }
 
             return result;
         }

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/InitializePaymentCommand.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/InitializePaymentCommand.cs
@@ -3,10 +3,7 @@ using VirtoCommerce.ExperienceApiModule.XOrder.Models;
 
 namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
 {
-    public class InitializePaymentCommand : ICommand<InitializePaymentResult>
+    public class InitializePaymentCommand : PaymentCommandBase, ICommand<InitializePaymentResult>
     {
-        public string OrderId { get; set; }
-
-        public string PaymentId { get; set; }
     }
 }

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/InitializePaymentCommand.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/InitializePaymentCommand.cs
@@ -1,0 +1,12 @@
+using VirtoCommerce.ExperienceApiModule.Core.Infrastructure;
+using VirtoCommerce.ExperienceApiModule.XOrder.Models;
+
+namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
+{
+    public class InitializePaymentCommand : ICommand<InitializePaymentResult>
+    {
+        public string OrderId { get; set; }
+
+        public string PaymentId { get; set; }
+    }
+}

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/InitializePaymentCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/InitializePaymentCommandHandler.cs
@@ -82,8 +82,6 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
 
             var result = await InitializePaymentAsync(paymentRequest);
 
-            await _customerOrderService.SaveChangesAsync(new[] { customerOrder });
-
             return result;
         }
 
@@ -126,7 +124,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
             return Task.FromResult(result);
         }
 
-        private InitializePaymentResult ErrorResult(string error)
+        private static InitializePaymentResult ErrorResult(string error)
         {
             return new InitializePaymentResult
             {

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/InitializePaymentCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/InitializePaymentCommandHandler.cs
@@ -1,11 +1,9 @@
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 using VirtoCommerce.ExperienceApiModule.XOrder.Models;
 using VirtoCommerce.ExperienceApiModule.XOrder.Validators;
 using VirtoCommerce.OrdersModule.Core.Model;
-using VirtoCommerce.PaymentModule.Core.Model;
 using VirtoCommerce.PaymentModule.Model.Requests;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.GenericCrud;
@@ -13,71 +11,34 @@ using VirtoCommerce.StoreModule.Core.Model;
 
 namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
 {
-    public class InitializePaymentCommandHandler : IRequestHandler<InitializePaymentCommand, InitializePaymentResult>
+    public class InitializePaymentCommandHandler : PaymentCommandHandlerBase, IRequestHandler<InitializePaymentCommand, InitializePaymentResult>
     {
-        private readonly ICrudService<CustomerOrder> _customerOrderService;
-        private readonly ICrudService<PaymentIn> _paymentService;
-        private readonly ICrudService<Store> _storeService;
-
         public InitializePaymentCommandHandler(
             ICrudService<CustomerOrder> customerOrderService,
             ICrudService<PaymentIn> paymentService,
             ICrudService<Store> storeService)
+            : base(customerOrderService, paymentService, storeService)
         {
-            _customerOrderService = customerOrderService;
-            _paymentService = paymentService;
-            _storeService = storeService;
         }
 
         public async Task<InitializePaymentResult> Handle(InitializePaymentCommand request, CancellationToken cancellationToken)
         {
-            var customerOrder = default(CustomerOrder);
-            var payment = default(PaymentIn);
+            var payment = await GetPaymentInfo(request);
 
-            if (!string.IsNullOrEmpty(request.OrderId))
+            var validationResult = ValidateRequest(payment, request);
+            if (validationResult != null)
             {
-                customerOrder = await _customerOrderService.GetByIdAsync(request.OrderId, CustomerOrderResponseGroup.Full.ToString());
-                payment = customerOrder?.InPayments?.FirstOrDefault(x => x.Id == request.PaymentId);
-            }
-            else if (!string.IsNullOrEmpty(request.PaymentId))
-            {
-                payment = await _paymentService.GetByIdAsync(request.PaymentId);
-                customerOrder = await _customerOrderService.GetByIdAsync(payment?.OrderId, CustomerOrderResponseGroup.Full.ToString());
-
-                // take payment from order since Order payment contains instanced PaymentMethod (payment taken from service doesn't)
-                payment = customerOrder?.InPayments?.FirstOrDefault(x => x.Id == request.PaymentId);
-            }
-
-            if (customerOrder == null)
-            {
-                return ErrorResult($"Cannot find order with ID {request.OrderId}");
-            }
-
-            if (payment == null)
-            {
-                return ErrorResult($"Cannot find payment with ID {request.PaymentId}");
-            }
-
-            if (payment.PaymentStatus == PaymentStatus.Paid)
-            {
-                return ErrorResult($"Document {payment.Number} is already paid");
-            }
-
-            var store = await _storeService.GetByIdAsync(customerOrder.StoreId, StoreResponseGroup.StoreInfo.ToString());
-
-            if (store == null)
-            {
-                return ErrorResult($"Cannot find store with ID {customerOrder.StoreId}");
+                return ErrorResult<InitializePaymentResult>(validationResult);
             }
 
             var paymentRequest = new ProcessPaymentRequest
             {
-                OrderId = customerOrder.Id,
-                Order = customerOrder,
-                PaymentId = payment.Id,
-                Payment = payment,
-                StoreId = store.Id,
-                Store = store,
+                OrderId = payment.CustomerOrder.Id,
+                Order = payment.CustomerOrder,
+                PaymentId = payment.Payment.Id,
+                Payment = payment.Payment,
+                StoreId = payment.Store.Id,
+                Store = payment.Store,
             };
 
             var result = await InitializePaymentAsync(paymentRequest);
@@ -85,7 +46,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
             return result;
         }
 
-        protected virtual Task<InitializePaymentResult> InitializePaymentAsync(ProcessPaymentRequest request)
+        private Task<InitializePaymentResult> InitializePaymentAsync(ProcessPaymentRequest request)
         {
             var order = request.Order as CustomerOrder;
 
@@ -123,15 +84,6 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
             }
 
             return Task.FromResult(result);
-        }
-
-        private static InitializePaymentResult ErrorResult(string error)
-        {
-            return new InitializePaymentResult
-            {
-                IsSuccess = false,
-                ErrorMessage = error,
-            };
         }
     }
 }

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/InitializePaymentCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/InitializePaymentCommandHandler.cs
@@ -1,0 +1,138 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using VirtoCommerce.ExperienceApiModule.XOrder.Models;
+using VirtoCommerce.ExperienceApiModule.XOrder.Validators;
+using VirtoCommerce.OrdersModule.Core.Model;
+using VirtoCommerce.PaymentModule.Core.Model;
+using VirtoCommerce.PaymentModule.Model.Requests;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.GenericCrud;
+using VirtoCommerce.StoreModule.Core.Model;
+
+namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
+{
+    public class InitializePaymentCommandHandler : IRequestHandler<InitializePaymentCommand, InitializePaymentResult>
+    {
+        private readonly ICrudService<CustomerOrder> _customerOrderService;
+        private readonly ICrudService<PaymentIn> _paymentService;
+        private readonly ICrudService<Store> _storeService;
+
+        public InitializePaymentCommandHandler(
+            ICrudService<CustomerOrder> customerOrderService,
+            ICrudService<PaymentIn> paymentService,
+            ICrudService<Store> storeService)
+        {
+            _customerOrderService = customerOrderService;
+            _paymentService = paymentService;
+            _storeService = storeService;
+        }
+
+        public async Task<InitializePaymentResult> Handle(InitializePaymentCommand request, CancellationToken cancellationToken)
+        {
+            var customerOrder = default(CustomerOrder);
+            var payment = default(PaymentIn);
+
+            if (!string.IsNullOrEmpty(request.OrderId))
+            {
+                customerOrder = await _customerOrderService.GetByIdAsync(request.OrderId, CustomerOrderResponseGroup.Full.ToString());
+                payment = customerOrder?.InPayments?.FirstOrDefault(x => x.Id == request.PaymentId);
+            }
+            else if (!string.IsNullOrEmpty(request.PaymentId))
+            {
+                payment = await _paymentService.GetByIdAsync(request.PaymentId);
+                customerOrder = await _customerOrderService.GetByIdAsync(payment?.OrderId, CustomerOrderResponseGroup.Full.ToString());
+
+                // take payment from order since Order payment contains instanced PaymentMethod (payment taken from service doesn't)
+                payment = customerOrder?.InPayments?.FirstOrDefault(x => x.Id == request.PaymentId);
+            }
+
+            if (customerOrder == null)
+            {
+                return ErrorResult($"Cannot find order with ID {request.OrderId}");
+            }
+
+            if (payment == null)
+            {
+                return ErrorResult($"Cannot find payment with ID {request.PaymentId}");
+            }
+
+            if (payment.PaymentStatus == PaymentStatus.Paid)
+            {
+                return ErrorResult($"Document {payment.Number} is already paid");
+            }
+
+            var store = await _storeService.GetByIdAsync(customerOrder.StoreId, StoreResponseGroup.StoreInfo.ToString());
+
+            if (store == null)
+            {
+                return ErrorResult($"Cannot find store with ID {customerOrder.StoreId}");
+            }
+
+            var paymentRequest = new ProcessPaymentRequest
+            {
+                OrderId = customerOrder.Id,
+                Order = customerOrder,
+                PaymentId = payment.Id,
+                Payment = payment,
+                StoreId = store.Id,
+                Store = store,
+            };
+
+            var result = await InitializePaymentAsync(paymentRequest);
+
+            await _customerOrderService.SaveChangesAsync(new[] { customerOrder });
+
+            return result;
+        }
+
+        protected virtual Task<InitializePaymentResult> InitializePaymentAsync(ProcessPaymentRequest request)
+        {
+            var order = request.Order as CustomerOrder;
+
+            var result = new InitializePaymentResult
+            {
+                StoreId = request.StoreId,
+                PaymentId = request.PaymentId,
+                OrderId = request.OrderId,
+                OrderNumber = order?.Number,
+            };
+
+            var validationResult = AbstractTypeFactory<ProcessPaymentRequestValidator>.TryCreateInstance().Validate(request);
+            if (!validationResult.IsValid)
+            {
+                result.IsSuccess = false;
+                result.ErrorMessage = string.Join(';', validationResult.Errors);
+            }
+
+            if (request.Payment is PaymentIn payment)
+            {
+                var processPaymentResult = payment.PaymentMethod.ProcessPayment(request);
+
+                if (processPaymentResult.OuterId != null)
+                {
+                    payment.OuterId = processPaymentResult.OuterId;
+                }
+
+                result.IsSuccess = processPaymentResult.IsSuccess;
+                result.ErrorMessage = processPaymentResult.ErrorMessage;
+                result.ActionHtmlForm = processPaymentResult.HtmlForm;
+                result.ActionRedirectUrl = processPaymentResult.RedirectUrl;
+                result.PaymentMethodCode = payment.PaymentMethod.Code;
+                result.PaymentActionType = payment.PaymentMethod.PaymentMethodType.ToString();
+            }
+
+            return Task.FromResult(result);
+        }
+
+        private InitializePaymentResult ErrorResult(string error)
+        {
+            return new InitializePaymentResult
+            {
+                IsSuccess = false,
+                ErrorMessage = error,
+            };
+        }
+    }
+}

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/InitializePaymentCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/InitializePaymentCommandHandler.cs
@@ -46,7 +46,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
             return result;
         }
 
-        private Task<InitializePaymentResult> InitializePaymentAsync(ProcessPaymentRequest request)
+        private static Task<InitializePaymentResult> InitializePaymentAsync(ProcessPaymentRequest request)
         {
             var order = request.Order as CustomerOrder;
 

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/InitializePaymentCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/InitializePaymentCommandHandler.cs
@@ -117,6 +117,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
                 result.ErrorMessage = processPaymentResult.ErrorMessage;
                 result.ActionHtmlForm = processPaymentResult.HtmlForm;
                 result.ActionRedirectUrl = processPaymentResult.RedirectUrl;
+                result.PublicParameters = processPaymentResult.PublicParameters;
                 result.PaymentMethodCode = payment.PaymentMethod.Code;
                 result.PaymentActionType = payment.PaymentMethod.PaymentMethodType.ToString();
             }

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/PaymentCommandBase.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/PaymentCommandBase.cs
@@ -1,0 +1,9 @@
+namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
+{
+    public class PaymentCommandBase
+    {
+        public string OrderId { get; set; }
+
+        public string PaymentId { get; set; }
+    }
+}

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/PaymentCommandHandlerBase.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/PaymentCommandHandlerBase.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using VirtoCommerce.ExperienceApiModule.Core.Models;
 using VirtoCommerce.ExperienceApiModule.XOrder.Models;
 using VirtoCommerce.OrdersModule.Core.Model;
-using VirtoCommerce.PaymentModule.Core.Model;
 using VirtoCommerce.Platform.Core.GenericCrud;
 using VirtoCommerce.StoreModule.Core.Model;
 
@@ -50,31 +49,6 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
             return result;
         }
 
-        protected static string ValidateRequest(PaymentInfo payment, PaymentCommandBase command)
-        {
-            if (payment.CustomerOrder == null)
-            {
-                return $"Cannot find order with ID {command.OrderId}";
-            }
-
-            if (payment.Payment == null)
-            {
-                return $"Cannot find payment with ID {command.PaymentId}";
-            }
-
-            if (payment.Payment.PaymentStatus == PaymentStatus.Paid)
-            {
-                return $"Document {payment.Payment.Number} is already paid";
-            }
-
-            if (payment.Store == null)
-            {
-                return $"Cannot find store with ID {payment.CustomerOrder?.StoreId}";
-            }
-
-            return null;
-        }
-
         protected static NameValueCollection GetParameters(AuthorizePaymentCommand request)
         {
             var parameters = new NameValueCollection();
@@ -93,15 +67,6 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
                 IsSuccess = false,
                 ErrorMessage = error,
             };
-        }
-
-        public class PaymentInfo
-        {
-            public CustomerOrder CustomerOrder { get; set; }
-
-            public PaymentIn Payment { get; set; }
-
-            public Store Store { get; set; }
         }
     }
 }

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/PaymentCommandHandlerBase.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/PaymentCommandHandlerBase.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Threading.Tasks;
+using VirtoCommerce.ExperienceApiModule.Core.Models;
+using VirtoCommerce.ExperienceApiModule.XOrder.Models;
+using VirtoCommerce.OrdersModule.Core.Model;
+using VirtoCommerce.PaymentModule.Core.Model;
+using VirtoCommerce.Platform.Core.GenericCrud;
+using VirtoCommerce.StoreModule.Core.Model;
+
+namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
+{
+    public abstract class PaymentCommandHandlerBase
+    {
+        private readonly ICrudService<CustomerOrder> _customerOrderService;
+        private readonly ICrudService<PaymentIn> _paymentService;
+        private readonly ICrudService<Store> _storeService;
+
+        public PaymentCommandHandlerBase(
+            ICrudService<CustomerOrder> customerOrderService,
+            ICrudService<PaymentIn> paymentService,
+            ICrudService<Store> storeService)
+        {
+            _customerOrderService = customerOrderService;
+            _paymentService = paymentService;
+            _storeService = storeService;
+        }
+
+        protected async Task<PaymentInfo> GetPaymentInfo(PaymentCommandBase command)
+        {
+            var result = new PaymentInfo();
+
+            if (!string.IsNullOrEmpty(command.OrderId))
+            {
+                result.CustomerOrder = await _customerOrderService.GetByIdAsync(command.OrderId, CustomerOrderResponseGroup.Full.ToString());
+                result.Payment = result.CustomerOrder?.InPayments?.FirstOrDefault(x => x.Id == command.PaymentId);
+            }
+            else if (!string.IsNullOrEmpty(command.PaymentId))
+            {
+                result.Payment = await _paymentService.GetByIdAsync(command.PaymentId);
+                result.CustomerOrder = await _customerOrderService.GetByIdAsync(result.Payment?.OrderId, CustomerOrderResponseGroup.Full.ToString());
+
+                // take payment from order since Order payment contains instanced PaymentMethod (payment taken from service doesn't)
+                result.Payment = result.CustomerOrder?.InPayments?.FirstOrDefault(x => x.Id == command.PaymentId);
+            }
+
+            result.Store = await _storeService.GetByIdAsync(result.CustomerOrder?.StoreId, StoreResponseGroup.StoreInfo.ToString());
+
+            return result;
+        }
+
+        protected static string ValidateRequest(PaymentInfo payment, PaymentCommandBase command)
+        {
+            if (payment.CustomerOrder == null)
+            {
+                return $"Cannot find order with ID {command.OrderId}";
+            }
+
+            if (payment.Payment == null)
+            {
+                return $"Cannot find payment with ID {command.PaymentId}";
+            }
+
+            if (payment.Payment.PaymentStatus == PaymentStatus.Paid)
+            {
+                return $"Document {payment.Payment.Number} is already paid";
+            }
+
+            if (payment.Store == null)
+            {
+                return $"Cannot find store with ID {payment.CustomerOrder?.StoreId}";
+            }
+
+            return null;
+        }
+
+        protected static NameValueCollection GetParameters(AuthorizePaymentCommand request)
+        {
+            var parameters = new NameValueCollection();
+            foreach (var param in request?.Parameters ?? Array.Empty<KeyValuePair>())
+            {
+                parameters.Add(param.Key, param.Value);
+            }
+
+            return parameters;
+        }
+
+        protected static T ErrorResult<T>(string error) where T : PaymentResult, new()
+        {
+            return new T
+            {
+                IsSuccess = false,
+                ErrorMessage = error,
+            };
+        }
+
+        public class PaymentInfo
+        {
+            public CustomerOrder CustomerOrder { get; set; }
+
+            public PaymentIn Payment { get; set; }
+
+            public Store Store { get; set; }
+        }
+    }
+}

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Models/AuthorizePaymentResult.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Models/AuthorizePaymentResult.cs
@@ -1,9 +1,6 @@
 namespace VirtoCommerce.ExperienceApiModule.XOrder.Models
 {
-    public class AuthorizePaymentResult
+    public class AuthorizePaymentResult : PaymentResult
     {
-        public bool IsSuccess { get; set; }
-
-        public string ErrorMessage { get; set; }
     }
 }

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Models/AuthorizePaymentResult.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Models/AuthorizePaymentResult.cs
@@ -1,0 +1,9 @@
+namespace VirtoCommerce.ExperienceApiModule.XOrder.Models
+{
+    public class AuthorizePaymentResult
+    {
+        public bool IsSuccess { get; set; }
+
+        public string ErrorMessage { get; set; }
+    }
+}

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Models/InitializePaymentResult.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Models/InitializePaymentResult.cs
@@ -1,0 +1,25 @@
+namespace VirtoCommerce.ExperienceApiModule.XOrder.Models
+{
+    public class InitializePaymentResult
+    {
+        public string StoreId { get; set; }
+
+        public string PaymentId { get; set; }
+
+        public string OrderId { get; set; }
+
+        public string OrderNumber { get; set; }
+
+        public string PaymentMethodCode { get; set; }
+
+        public string PaymentActionType { get; set; }
+
+        public string ActionRedirectUrl { get; set; }
+
+        public string ActionHtmlForm { get; set; }
+
+        public bool IsSuccess { get; set; }
+
+        public string ErrorMessage { get; set; }
+    }
+}

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Models/InitializePaymentResult.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Models/InitializePaymentResult.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace VirtoCommerce.ExperienceApiModule.XOrder.Models
 {
     public class InitializePaymentResult
@@ -21,5 +23,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Models
         public bool IsSuccess { get; set; }
 
         public string ErrorMessage { get; set; }
+
+        public Dictionary<string, string> PublicParameters { get; set; } = new();
     }
 }

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Models/InitializePaymentResult.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Models/InitializePaymentResult.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace VirtoCommerce.ExperienceApiModule.XOrder.Models
 {
-    public class InitializePaymentResult
+    public class InitializePaymentResult : PaymentResult
     {
         public string StoreId { get; set; }
 
@@ -19,10 +19,6 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Models
         public string ActionRedirectUrl { get; set; }
 
         public string ActionHtmlForm { get; set; }
-
-        public bool IsSuccess { get; set; }
-
-        public string ErrorMessage { get; set; }
 
         public Dictionary<string, string> PublicParameters { get; set; } = new();
     }

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Models/PaymentInfo.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Models/PaymentInfo.cs
@@ -1,0 +1,14 @@
+using VirtoCommerce.OrdersModule.Core.Model;
+using VirtoCommerce.StoreModule.Core.Model;
+
+namespace VirtoCommerce.ExperienceApiModule.XOrder.Models
+{
+    public class PaymentInfo
+    {
+        public CustomerOrder CustomerOrder { get; set; }
+
+        public PaymentIn Payment { get; set; }
+
+        public Store Store { get; set; }
+    }
+}

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Models/PaymentResult.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Models/PaymentResult.cs
@@ -1,0 +1,9 @@
+namespace VirtoCommerce.ExperienceApiModule.XOrder.Models
+{
+    public class PaymentResult
+    {
+        public bool IsSuccess { get; set; }
+
+        public string ErrorMessage { get; set; }
+    }
+}

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/OrderErrorDescriber.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/OrderErrorDescriber.cs
@@ -6,7 +6,17 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder
     {
         public static string InvalidStatus(PaymentStatus status, PaymentStatus[] availStatuses)
         {
-            return  $"Unable to process due to invalid payment status: {status}. Only {string.Join(',', availStatuses)} statuses are available for processing.";
+            return $"Unable to process due to invalid payment status: {status}. Only {string.Join(',', availStatuses)} statuses are available for processing.";
+        }
+
+        public static string InvalidStatus(PaymentStatus status)
+        {
+            return $"Unable to process due to invalid payment status: {status}";
+        }
+
+        public static string OrderNotFound()
+        {
+            return $"Can't find customer order";
         }
 
         public static string PaymentNotFound()
@@ -23,6 +33,5 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder
         {
             return $"Can't find a store";
         }
-
     }
 }

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/AuthorizePaymentResultType.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/AuthorizePaymentResultType.cs
@@ -1,0 +1,14 @@
+using GraphQL.Types;
+using VirtoCommerce.ExperienceApiModule.XOrder.Models;
+
+namespace VirtoCommerce.ExperienceApiModule.XOrder.Schemas
+{
+    public class AuthorizePaymentResultType : ObjectGraphType<AuthorizePaymentResult>
+    {
+        public AuthorizePaymentResultType()
+        {
+            Field(x => x.IsSuccess);
+            Field(x => x.ErrorMessage, nullable: true);
+        }
+    }
+}

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/InitializePaymentResultType.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/InitializePaymentResultType.cs
@@ -1,4 +1,6 @@
+using GraphQL;
 using GraphQL.Types;
+using VirtoCommerce.ExperienceApiModule.Core.Schemas;
 using VirtoCommerce.ExperienceApiModule.XOrder.Models;
 
 namespace VirtoCommerce.ExperienceApiModule.XOrder.Schemas
@@ -17,6 +19,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Schemas
             Field(x => x.PaymentActionType, nullable: true);
             Field(x => x.ActionRedirectUrl, nullable: true);
             Field(x => x.ActionHtmlForm, nullable: true);
+            Field<ListGraphType<KeyValueType>>(nameof(InitializePaymentResult.PublicParameters).ToCamelCase(), resolve: context => context.Source.PublicParameters);
         }
     }
 }

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/InitializePaymentResultType.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/InitializePaymentResultType.cs
@@ -1,5 +1,7 @@
+using System.Linq;
 using GraphQL;
 using GraphQL.Types;
+using VirtoCommerce.ExperienceApiModule.Core.Models;
 using VirtoCommerce.ExperienceApiModule.Core.Schemas;
 using VirtoCommerce.ExperienceApiModule.XOrder.Models;
 
@@ -19,7 +21,8 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Schemas
             Field(x => x.PaymentActionType, nullable: true);
             Field(x => x.ActionRedirectUrl, nullable: true);
             Field(x => x.ActionHtmlForm, nullable: true);
-            Field<ListGraphType<KeyValueType>>(nameof(InitializePaymentResult.PublicParameters).ToCamelCase(), resolve: context => context.Source.PublicParameters);
+            Field<ListGraphType<KeyValueType>>(nameof(InitializePaymentResult.PublicParameters).ToCamelCase(), resolve: context =>
+                context.Source.PublicParameters?.Select(x => new KeyValuePair { Key = x.Key, Value = x.Value }));
         }
     }
 }

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/InitializePaymentResultType.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/InitializePaymentResultType.cs
@@ -1,0 +1,22 @@
+using GraphQL.Types;
+using VirtoCommerce.ExperienceApiModule.XOrder.Models;
+
+namespace VirtoCommerce.ExperienceApiModule.XOrder.Schemas
+{
+    public class InitializePaymentResultType : ObjectGraphType<InitializePaymentResult>
+    {
+        public InitializePaymentResultType()
+        {
+            Field(x => x.IsSuccess);
+            Field(x => x.ErrorMessage, nullable: true);
+            Field(x => x.StoreId, nullable: true);
+            Field(x => x.PaymentId, nullable: true);
+            Field(x => x.OrderId, nullable: true);
+            Field(x => x.OrderNumber, nullable: true);
+            Field(x => x.PaymentMethodCode, nullable: true);
+            Field(x => x.PaymentActionType, nullable: true);
+            Field(x => x.ActionRedirectUrl, nullable: true);
+            Field(x => x.ActionHtmlForm, nullable: true);
+        }
+    }
+}

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/InputAuthorizePaymentType.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/InputAuthorizePaymentType.cs
@@ -1,0 +1,16 @@
+using GraphQL.Types;
+using VirtoCommerce.ExperienceApiModule.Core.Schemas;
+
+namespace VirtoCommerce.ExperienceApiModule.XOrder.Schemas
+{
+    public class InputAuthorizePaymentType : InputObjectGraphType
+    {
+        public InputAuthorizePaymentType()
+        {
+            Field<StringGraphType>("orderId", "Order Id");
+            Field<NonNullGraphType<StringGraphType>>("paymentId", "Payment Id");
+            //Field<StringGraphType>("paymentMethodCode", "Payment Id");
+            Field<ListGraphType<InputKeyValueType>>("parameters", "Input parameters");
+        }
+    }
+}

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/InputAuthorizePaymentType.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/InputAuthorizePaymentType.cs
@@ -9,7 +9,6 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Schemas
         {
             Field<StringGraphType>("orderId", "Order Id");
             Field<NonNullGraphType<StringGraphType>>("paymentId", "Payment Id");
-            //Field<StringGraphType>("paymentMethodCode", "Payment Id");
             Field<ListGraphType<InputKeyValueType>>("parameters", "Input parameters");
         }
     }

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/InputInitializePaymentType.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/InputInitializePaymentType.cs
@@ -1,0 +1,13 @@
+using GraphQL.Types;
+
+namespace VirtoCommerce.ExperienceApiModule.XOrder.Schemas
+{
+    public class InputInitializePaymentType : InputObjectGraphType
+    {
+        public InputInitializePaymentType()
+        {
+            Field<StringGraphType>("orderId", "Order Id");
+            Field<NonNullGraphType<StringGraphType>>("paymentId", "Payment Id");
+        }
+    }
+}

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/OrderPaymentMethodType.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/OrderPaymentMethodType.cs
@@ -27,7 +27,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Schemas
             Field(x => x.IsAvailableForPartial);
             Field(x => x.Priority);
             Field(x => x.IsActive);
-            Field(x => x.LogoUrl);
+            Field(x => x.LogoUrl, nullable: true);
             Field(x => x.Code);
             Field(x => x.Description, nullable: true);
             Field<IntGraphType>(nameof(PaymentMethod.PaymentMethodType), resolve: context => (int)context.Source.PaymentMethodType);

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/OrderSchema.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/OrderSchema.cs
@@ -150,7 +150,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Schemas
                                 var type = GenericTypeHelper.GetActualType<AuthorizePaymentCommand>();
 
                                 var command = (AuthorizePaymentCommand)context.GetArgument(type, _commandName);
-                                //await CheckAuthAsync(context, command.OrderId);
+                                await CheckAuthAsync(context, command.OrderId);
 
                                 return await _mediator.Send(command);
                             })

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/OrderSchema.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/OrderSchema.cs
@@ -142,6 +142,20 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Schemas
                             })
                             .FieldType);
 
+            _ = schema.Mutation.AddField(FieldBuilder.Create<object, AuthorizePaymentResult>(typeof(AuthorizePaymentResultType))
+                            .Name("authorizePayment")
+                            .Argument(GraphTypeExtenstionHelper.GetActualComplexType<NonNullGraphType<InputAuthorizePaymentType>>(), _commandName)
+                            .ResolveAsync(async context =>
+                            {
+                                var type = GenericTypeHelper.GetActualType<AuthorizePaymentCommand>();
+
+                                var command = (AuthorizePaymentCommand)context.GetArgument(type, _commandName);
+                                //await CheckAuthAsync(context, command.OrderId);
+
+                                return await _mediator.Send(command);
+                            })
+                            .FieldType);
+
 
             _ = schema.Mutation.AddField(FieldBuilder.Create<CustomerOrderAggregate, CustomerOrderAggregate>(GraphTypeExtenstionHelper.GetActualType<CustomerOrderType>())
                             .Name("updateOrderDynamicProperties")

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/OrderSchema.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Schemas/OrderSchema.cs
@@ -13,6 +13,7 @@ using VirtoCommerce.ExperienceApiModule.Core.Infrastructure.Authorization;
 using VirtoCommerce.ExperienceApiModule.XOrder.Authorization;
 using VirtoCommerce.ExperienceApiModule.XOrder.Commands;
 using VirtoCommerce.ExperienceApiModule.XOrder.Extensions;
+using VirtoCommerce.ExperienceApiModule.XOrder.Models;
 using VirtoCommerce.ExperienceApiModule.XOrder.Queries;
 using VirtoCommerce.OrdersModule.Core.Model;
 using VirtoCommerce.OrdersModule.Core.Services;
@@ -120,6 +121,21 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Schemas
                             {
                                 var type = GenericTypeHelper.GetActualType<ProcessOrderPaymentCommand>();
                                 var command = (ProcessOrderPaymentCommand)context.GetArgument(type, _commandName);
+                                await CheckAuthAsync(context, command.OrderId);
+
+                                return await _mediator.Send(command);
+                            })
+                            .DeprecationReason("Obsolete. Use 'initializePayment' mutation")
+                            .FieldType);
+
+            _ = schema.Mutation.AddField(FieldBuilder.Create<object, InitializePaymentResult>(typeof(InitializePaymentResultType))
+                            .Name("initializePayment")
+                            .Argument(GraphTypeExtenstionHelper.GetActualComplexType<NonNullGraphType<InputInitializePaymentType>>(), _commandName)
+                            .ResolveAsync(async context =>
+                            {
+                                var type = GenericTypeHelper.GetActualType<InitializePaymentCommand>();
+
+                                var command = (InitializePaymentCommand)context.GetArgument(type, _commandName);
                                 await CheckAuthAsync(context, command.OrderId);
 
                                 return await _mediator.Send(command);

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Validators/PaymentRequestValidator.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Validators/PaymentRequestValidator.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Linq;
+using FluentValidation;
+using VirtoCommerce.ExperienceApiModule.XOrder.Models;
+using VirtoCommerce.PaymentModule.Core.Model;
+
+namespace VirtoCommerce.ExperienceApiModule.XOrder.Validators
+{
+    public class PaymentRequestValidator : AbstractValidator<PaymentInfo>
+    {
+        private readonly PaymentStatus[] _invalidStates = new[] { PaymentStatus.Paid };
+
+        public PaymentRequestValidator()
+        {
+            RuleFor(x => x.CustomerOrder)
+                .NotNull()
+                .WithMessage(OrderErrorDescriber.OrderNotFound());
+
+            RuleFor(x => x.Payment)
+                .NotNull()
+                .WithMessage(OrderErrorDescriber.PaymentNotFound());
+
+            RuleFor(x => x.Payment.PaymentMethod)
+                .NotNull()
+                .WithMessage(x => OrderErrorDescriber.PaymentMethodNotFound(x.Payment.GatewayCode))
+                .When(x => x.Payment != null);
+
+            RuleFor(x => x.Store)
+                .NotNull()
+                .WithMessage(OrderErrorDescriber.StoreNotFound());
+
+            RuleFor(x => x)
+                .Custom((request, context) =>
+                {
+                    if (_invalidStates.Contains(request.Payment.PaymentStatus))
+                    {
+                        context.AddFailure(OrderErrorDescriber.InvalidStatus(request.Payment.PaymentStatus));
+                    }
+                })
+                .When(x => x.Payment != null);
+        }
+    }
+}

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/VirtoCommerce.ExperienceApiModule.XOrder.csproj
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/VirtoCommerce.ExperienceApiModule.XOrder.csproj
@@ -22,7 +22,7 @@
         <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.200.0" />
         <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.200.0" />
         <PackageReference Include="VirtoCommerce.OrdersModule.Data" Version="3.200.0" />
-        <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.204.0-beta1" />
+        <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.204.0" />
         <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.207.0" />
         <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.200.0" />
     </ItemGroup>

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/VirtoCommerce.ExperienceApiModule.XOrder.csproj
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/VirtoCommerce.ExperienceApiModule.XOrder.csproj
@@ -22,7 +22,7 @@
         <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.200.0" />
         <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.200.0" />
         <PackageReference Include="VirtoCommerce.OrdersModule.Data" Version="3.200.0" />
-        <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.201.0" />
+        <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.204.0-beta1" />
         <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.207.0" />
         <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.200.0" />
     </ItemGroup>

--- a/src/XPurchase/VirtoCommerce.XPurchase/Schemas/PurchaseSchema.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Schemas/PurchaseSchema.cs
@@ -946,11 +946,7 @@ namespace VirtoCommerce.XPurchase.Schemas
 
                                                      await CheckAuthByCartCommandAsync(context, cartCommand);
 
-                                                     var result = await _mediator.Send(cartCommand);
-
-                                                     context.SetExpandedObjectGraph(result.Cart);
-
-                                                     return result;
+                                                     return await _mediator.Send(cartCommand);
                                                  })
                                                  .FieldType;
 

--- a/src/XPurchase/VirtoCommerce.XPurchase/Schemas/PurchaseSchema.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Schemas/PurchaseSchema.cs
@@ -946,7 +946,11 @@ namespace VirtoCommerce.XPurchase.Schemas
 
                                                      await CheckAuthByCartCommandAsync(context, cartCommand);
 
-                                                     return await _mediator.Send(cartCommand);
+                                                     var result = await _mediator.Send(cartCommand);
+
+                                                     context.SetExpandedObjectGraph(result.Cart);
+
+                                                     return result;
                                                  })
                                                  .FieldType;
 

--- a/src/XPurchase/VirtoCommerce.XPurchase/VirtoCommerce.XPurchase.csproj
+++ b/src/XPurchase/VirtoCommerce.XPurchase/VirtoCommerce.XPurchase.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.201.0" />
         <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.200.0" />
         <PackageReference Include="VirtoCommerce.MarketingModule.Data" Version="3.200.0" />
-        <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.204.0-beta1" />
+        <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.204.0" />
         <PackageReference Include="VirtoCommerce.ShippingModule.Core" Version="3.200.0" />
         <PackageReference Include="VirtoCommerce.Tools" Version="3.200.0" />
         <PackageReference Include="VirtoCommerce.TaxModule.Core" Version="3.200.0" />

--- a/src/XPurchase/VirtoCommerce.XPurchase/VirtoCommerce.XPurchase.csproj
+++ b/src/XPurchase/VirtoCommerce.XPurchase/VirtoCommerce.XPurchase.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.201.0" />
         <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.200.0" />
         <PackageReference Include="VirtoCommerce.MarketingModule.Data" Version="3.200.0" />
-        <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.201.0" />
+        <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.204.0-beta1" />
         <PackageReference Include="VirtoCommerce.ShippingModule.Core" Version="3.200.0" />
         <PackageReference Include="VirtoCommerce.Tools" Version="3.200.0" />
         <PackageReference Include="VirtoCommerce.TaxModule.Core" Version="3.200.0" />


### PR DESCRIPTION
## Description
```js
mutation {
  initializePayment(command: {
    orderId: "123",
    paymentId: "345"
  }) {
    isSuccess
    errorMessage
    storeId
    paymentId
    orderId
    orderNumber
    paymentMethodCode
    paymentActionType
    actionRedirectUrl
    actionHtmlForm
    publicParameters {
      key
      value
    }
  }
}
```
--------------------
```js
mutation {
  authorizePayment(command: {
    orderId: "123",
    paymentId: "345"
    parameters: [
      { 
        key: "dataValue", 
        value: "123"
      },
      { 
        key: "dataDescriptor", 
        value: "456" 
      }
    ]
  }) {
    isSuccess
    errorMessage
  }
}
```
## References
### QA-test:
### Jira-link:









https://virtocommerce.atlassian.net/browse/PT-7542
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.213.0-pr-309.zip
