### PR TITLE
PT-8162: add key property support

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Extensions/PropertyExtensions.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Extensions/PropertyExtensions.cs
@@ -39,6 +39,27 @@ namespace VirtoCommerce.XDigitalCatalog.Extensions
             }).ToList();
         }
 
+        /// <summary>
+        /// Filters and sorts properties by KeyProperty attribute, then flattens the key-value tree
+        /// </summary>
+        public static IList<Property> ExpandKeyPropertiesByValues(this IEnumerable<Property> properties, string cultureName, int take = 0)
+        {
+            properties = properties
+                .Where(x => x.Attributes.Any(a => a.Name.EqualsInvariant(XDigitalCatalogConstants.KeyProperty)))
+                .OrderBy(x =>
+                {
+                    var keyPropertyAttr = x.Attributes.First(x => x.Name.EqualsInvariant(XDigitalCatalogConstants.KeyProperty));
+                    return keyPropertyAttr.Value.TryParse(int.MaxValue);
+                });
+
+            if (take > 0)
+            {
+                properties = properties.Take(take);
+            }
+
+            return properties.ExpandByValues(cultureName);
+        }
+
         public static Property CopyPropertyWithValue(this PropertyValue propertyValue, Property property)
         {
             var clonedProperty = (Property)property.Clone();

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Extensions/PropertyExtensions.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Extensions/PropertyExtensions.cs
@@ -53,8 +53,8 @@ namespace VirtoCommerce.XDigitalCatalog.Extensions
                 .Where(x => !x.Attributes.IsNullOrEmpty() && x.Attributes.Any(a => a.Name.EqualsInvariant(XDigitalCatalogConstants.KeyProperty)))
                 .OrderBy(x =>
                 {
-                    var keyPropertyAttr = x.Attributes.First(x => x.Name.EqualsInvariant(XDigitalCatalogConstants.KeyProperty));
-                    return keyPropertyAttr.Value.TryParse(int.MaxValue);
+                    var keyPropertyAttr = x.Attributes?.FirstOrDefault(x => x.Name.EqualsInvariant(XDigitalCatalogConstants.KeyProperty));
+                    return keyPropertyAttr?.Value.TryParse(int.MaxValue);
                 });
 
             if (take > 0)

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Extensions/PropertyExtensions.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Extensions/PropertyExtensions.cs
@@ -44,8 +44,13 @@ namespace VirtoCommerce.XDigitalCatalog.Extensions
         /// </summary>
         public static IList<Property> ExpandKeyPropertiesByValues(this IEnumerable<Property> properties, string cultureName, int take = 0)
         {
+            if (properties.IsNullOrEmpty())
+            {
+                return new List<Property>();
+            }
+
             properties = properties
-                .Where(x => x.Attributes.Any(a => a.Name.EqualsInvariant(XDigitalCatalogConstants.KeyProperty)))
+                .Where(x => x.Attributes?.Any(a => a.Name.EqualsInvariant(XDigitalCatalogConstants.KeyProperty)) == true)
                 .OrderBy(x =>
                 {
                     var keyPropertyAttr = x.Attributes.First(x => x.Name.EqualsInvariant(XDigitalCatalogConstants.KeyProperty));

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Extensions/PropertyExtensions.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Extensions/PropertyExtensions.cs
@@ -50,7 +50,7 @@ namespace VirtoCommerce.XDigitalCatalog.Extensions
             }
 
             properties = properties
-                .Where(x => x.Attributes?.Any(a => a.Name.EqualsInvariant(XDigitalCatalogConstants.KeyProperty)) == true)
+                .Where(x => !x.Attributes.IsNullOrEmpty() && x.Attributes.Any(a => a.Name.EqualsInvariant(XDigitalCatalogConstants.KeyProperty)))
                 .OrderBy(x =>
                 {
                     var keyPropertyAttr = x.Attributes.First(x => x.Name.EqualsInvariant(XDigitalCatalogConstants.KeyProperty));

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Extensions/StringExtensions.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Extensions/StringExtensions.cs
@@ -1,0 +1,17 @@
+namespace VirtoCommerce.XDigitalCatalog.Extensions
+{
+    public static class StringExtensions
+    {
+        public static int TryParse(this string input, int defaultValue)
+        {
+            var result = defaultValue;
+
+            if (!string.IsNullOrEmpty(input) && int.TryParse(input, out var parseResult))
+            {
+                result = parseResult;
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Schemas/ProductType.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Schemas/ProductType.cs
@@ -287,6 +287,18 @@ namespace VirtoCommerce.XDigitalCatalog.Schemas
                 return result;
             });
 
+            ExtendableField<ListGraphType<PropertyType>>("keyProperties",
+                arguments: new QueryArguments(new QueryArgument<IntGraphType> { Name = "take" }),
+                resolve: context =>
+                {
+                    var take = context.GetArgument<int>("take");
+                    var cultureName = context.GetValue<string>("cultureName");
+
+                    var result = context.Source.IndexedProduct.Properties.ExpandKeyPropertiesByValues(cultureName, take);
+
+                    return result;
+                });
+
             Field<ListGraphType<AssetType>>(
                 "assets",
                 "Assets",

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/XDigitalCatalogConstants.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/XDigitalCatalogConstants.cs
@@ -1,0 +1,7 @@
+namespace VirtoCommerce.XDigitalCatalog
+{
+    public class XDigitalCatalogConstants
+    {
+        public const string KeyProperty = "KeyProperty";
+    }
+}


### PR DESCRIPTION
## Description

```js
query {
  products(
    storeId: "B2B-store"
    cultureName: "en-US"
  ) {
    items {
      code
      keyProperties (take:3) {
        name
        value
        valueType
      }
    }
  }
}
```
----
To use key propeties add `KeyProperty` attribute to property attributes. Value - int, ascending order.

## References
### QA-test:
### Jira-link:



https://virtocommerce.atlassian.net/browse/PT-8162
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.218.0-pr-322.zip
