### PR TITLE
PT-8543 "Get all carts" request authorization rules failed (XAPI)

### DIFF
--- a/src/XPurchase/VirtoCommerce.XPurchase/Authorization/CanAccessCartAuthorizationRequirement .cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Authorization/CanAccessCartAuthorizationRequirement .cs
@@ -33,7 +33,7 @@ namespace VirtoCommerce.XPurchase.Authorization
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, CanAccessCartAuthorizationRequirement requirement)
         {
             var result = context.User.IsInRole(PlatformConstants.Security.SystemRoles.Administrator);
-            
+
             if (!result)
             {
                 switch (context.Resource)
@@ -58,7 +58,15 @@ namespace VirtoCommerce.XPurchase.Authorization
                         break;
                     case SearchCartQuery searchQuery:
                         var currentUserId = GetUserId(context);
-                        result = searchQuery.UserId == currentUserId;
+                        if (searchQuery.UserId != null)
+                        {
+                            result = searchQuery.UserId == currentUserId;
+                        }
+                        else
+                        {
+                            searchQuery.UserId = currentUserId;
+                            result = searchQuery.UserId != null;
+                        }
                         break;
                 }
             }


### PR DESCRIPTION
## Description
if searchQuery contains UserId = User_1:
     1) User_1 : Access allowed for Cart_1
     2) Anonymous : Access allowed for Cart_1
     3) User_2: Access denied for Cart_1
if searchQuery does not contain UserId:
     1) User_1 : Access allowed for Cart_1
     2) Anonymous : Access denied for Cart_1
     3) User_2: Access allowed for Cart_2

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-8543
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.225.0-pr-335.zip
