### PR TITLE
PT-10279: Argument Null Exception if Category object is null.

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Schemas/CategoryType.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Schemas/CategoryType.cs
@@ -31,8 +31,11 @@ namespace VirtoCommerce.XDigitalCatalog.Schemas
 
             FieldAsync<StringGraphType>("outline", resolve: async context =>
              {
-                 var outlines = context.Source.Category.Outlines;
-                 if (outlines.IsNullOrEmpty()) return null;
+                 var outlines = context.Source.Category?.Outlines;
+                 if (outlines.IsNullOrEmpty())
+                 {
+                     return null;
+                 }
 
                  var loadRelatedCatalogOutlineQuery = context.GetCatalogQuery<LoadRelatedCatalogOutlineQuery>();
                  loadRelatedCatalogOutlineQuery.Outlines = outlines;
@@ -43,8 +46,11 @@ namespace VirtoCommerce.XDigitalCatalog.Schemas
 
             FieldAsync<StringGraphType>("slug", resolve: async context =>
             {
-                var outlines = context.Source.Category.Outlines;
-                if (outlines.IsNullOrEmpty()) return null;
+                var outlines = context.Source.Category?.Outlines;
+                if (outlines.IsNullOrEmpty())
+                {
+                    return null;
+                }
 
                 var loadRelatedSlugPathQuery = context.GetCatalogQuery<LoadRelatedSlugPathQuery>();
                 loadRelatedSlugPathQuery.Outlines = outlines;
@@ -168,8 +174,11 @@ namespace VirtoCommerce.XDigitalCatalog.Schemas
         private static bool TryGetCategoryParentId(IResolveFieldContext<ExpCategory> context, out string parentId)
         {
             parentId = null;
-            var outlines = context.Source.Category.Outlines;
-            if (outlines.IsNullOrEmpty()) return false;
+            var outlines = context.Source.Category?.Outlines;
+            if (outlines.IsNullOrEmpty())
+            {
+                return false;
+            }
 
             var store = context.GetArgumentOrValue<Store>("store");
 


### PR DESCRIPTION
## Description
fix: Argument Null Exception. Add null check if the Category object is null.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-10279
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.249.0-pr-366-2616.zip
