### PR TITLE
PT-10149: IFiltertExtensions.GetFieldName bug for __outiline field

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Extensions/IFiltertExtensions.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Extensions/IFiltertExtensions.cs
@@ -38,9 +38,18 @@ namespace VirtoCommerce.XDigitalCatalog.Extensions
         public static IList<IFilter> GetChildFilters(this SearchRequest searchRequest) =>
             (searchRequest?.Filter as AndFilter)?.ChildFilters ?? Array.Empty<IFilter>();
 
-        public static string GetFieldName(this IFilter filter) =>
+        public static string GetFieldName(this IFilter filter)
+        {
             // TermFilter names are equal, RangeFilter can contain underscore in the name
-            (filter as INamedFilter)?.FieldName?.Split('_')[0];
+            var fieldName = (filter as INamedFilter)?.FieldName;
+            if (string.IsNullOrEmpty(fieldName))
+                return fieldName;
+
+            if (fieldName.StartsWith("__"))
+                return fieldName;
+
+            return fieldName.Split('_')[0];
+        }
 
         public static void FillIsAppliedForItems(this IFilter filter, IEnumerable<AggregationItem> aggregationItems)
         {

--- a/tests/VirtoCommerce.XDigitalCatalog.Tests/Extensions/IFilterExtensionTests.cs
+++ b/tests/VirtoCommerce.XDigitalCatalog.Tests/Extensions/IFilterExtensionTests.cs
@@ -79,6 +79,7 @@ namespace VirtoCommerce.XDigitalCatalog.Tests.Extensions
         [InlineData("any Name", "any Name")]
         [InlineData("anyName_2384765", "anyName")]
         [InlineData("anyName_2384765_236745236", "anyName")]
+        [InlineData("__outline", "__outline")]
         public void GetFieldName_NamedFilter_ParsedCorrectly(string fieldName, string expectedName)
         {
             // Arrage


### PR DESCRIPTION
## Description
fix: IFiltertExtensions.GetFieldName bug for __outiline field

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-10149
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.251.0-pr-369-52b4.zip
