### PR TITLE
AutoMapper & Mediatr, remove obsolete

### DIFF
--- a/samples/PetsStoreClient/PetsStoreClient.csproj
+++ b/samples/PetsStoreClient/PetsStoreClient.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="AutoMapper" Version="10.1.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/RecommendationsGatewayModule/RecommendationsGatewayModule.Data/RecommendationsGatewayModule.Data.csproj
+++ b/samples/RecommendationsGatewayModule/RecommendationsGatewayModule.Data/RecommendationsGatewayModule.Data.csproj
@@ -1,16 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>  
+        <TargetFramework>net6.0</TargetFramework>
         <noWarn>1591</noWarn>
         <Description></Description>
         <IsPackable>True</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-   
-        <PackageReference Include="MediatR" Version="8.0.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.13" />
         <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.271.0" />
         <PackageReference Include="Scriban" Version="2.1.1" />
     </ItemGroup>

--- a/samples/RecommendationsGatewayModule/RecommendationsGatewayModule.Web/RecommendationsGatewayModule.Web.csproj
+++ b/samples/RecommendationsGatewayModule/RecommendationsGatewayModule.Web/RecommendationsGatewayModule.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>      
+        <TargetFramework>net6.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>-->
         <IsPackable>False</IsPackable>
@@ -14,9 +14,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.0" />
-    </ItemGroup>   
+    </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\..\..\src\VirtoCommerce.ExperienceApiModule.Core\VirtoCommerce.ExperienceApiModule.Core.csproj" />

--- a/samples/VCCatalogClient/VCCatalogClient.csproj
+++ b/samples/VCCatalogClient/VCCatalogClient.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/VirtoCommerce.Exp.ExtensionSamples/VirtoCommerce.Exp.ExtensionSamples.csproj
+++ b/samples/VirtoCommerce.Exp.ExtensionSamples/VirtoCommerce.Exp.ExtensionSamples.csproj
@@ -10,11 +10,8 @@
         <StartupObject />
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="AutoMapper" Version="10.0.0" />
-        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
         <PackageReference Include="GraphQL.DataLoader" Version="4.6.0" />
-        <PackageReference Include="MediatR" Version="8.0.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.13" />
         <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.271.0" />
         <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.271.0" />
         <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.210.0" />

--- a/src/VirtoCommerce.ExperienceApiModule.Core/VirtoCommerce.ExperienceApiModule.Core.csproj
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/VirtoCommerce.ExperienceApiModule.Core.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Description>Experiene API functionality</Description>
         <TargetFramework>net6.0</TargetFramework>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>     
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <noWarn>1591</noWarn>
         <IsPackable>True</IsPackable>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -23,26 +23,25 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoMapper" Version="10.0.0" />
-        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
-        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.0.0" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-        <PackageReference Include="PipelineNet" Version="0.9.0" />     
-        <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.203.0" />     
-        <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.210.0" />     
+        <PackageReference Include="MediatR" Version="9.0.0" />
+        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+        <PackageReference Include="AutoMapper" Version="10.1.1" />
+        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+        <PackageReference Include="PipelineNet" Version="0.9.0" />
+        <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.203.0" />
+        <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.210.0" />
         <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.201.0" />
         <PackageReference Include="VirtoCommerce.TaxModule.Core" Version="3.200.0" />
         <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.204.0" />
         <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.271.0" />
         <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.271.0" />
         <PackageReference Include="VirtoCommerce.Tools" Version="3.200.0" />
-        <PackageReference Include="MediatR" Version="8.0.1" />
         <PackageReference Include="GraphQL" Version="4.6.0" />
         <PackageReference Include="GraphQL.Authorization" Version="4.0.0" />
         <PackageReference Include="GraphQL.Relay" Version="0.6.2" />
         <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="5.0.2" />
         <PackageReference Include="GraphQL.Server.Transports.AspNetCore.NewtonsoftJson" Version="5.0.2" />
-        
     </ItemGroup>
 
 </Project>

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/CatalogQueryBuilder.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/CatalogQueryBuilder.cs
@@ -8,7 +8,8 @@ using Microsoft.AspNetCore.Authorization;
 using VirtoCommerce.CoreModule.Core.Currency;
 using VirtoCommerce.ExperienceApiModule.Core.BaseQueries;
 using VirtoCommerce.ExperienceApiModule.Core.Extensions;
-using VirtoCommerce.StoreModule.Core.Services;
+using VirtoCommerce.Platform.Core.GenericCrud;
+using VirtoCommerce.StoreModule.Core.Model;
 
 namespace VirtoCommerce.XDigitalCatalog.Queries;
 
@@ -17,13 +18,13 @@ public abstract class CatalogQueryBuilder<TQuery, TResult, TResultGraphType>
     where TQuery : CatalogQueryBase<TResult>
     where TResultGraphType : IGraphType
 {
-    private readonly IStoreService _storeService;
+    private readonly ICrudService<Store> _storeService;
     private readonly ICurrencyService _currencyService;
 
     protected CatalogQueryBuilder(
         IMediator mediator,
         IAuthorizationService authorizationService,
-        IStoreService storeService,
+        ICrudService<Store> storeService,
         ICurrencyService currencyService)
         : base(mediator, authorizationService)
     {

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/ChildCategoriesQueryBuilder.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/ChildCategoriesQueryBuilder.cs
@@ -8,7 +8,8 @@ using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.CatalogModule.Core.Services;
 using VirtoCommerce.CoreModule.Core.Currency;
 using VirtoCommerce.Platform.Core.Common;
-using VirtoCommerce.StoreModule.Core.Services;
+using VirtoCommerce.Platform.Core.GenericCrud;
+using VirtoCommerce.StoreModule.Core.Model;
 using VirtoCommerce.XDigitalCatalog.Extensions;
 
 namespace VirtoCommerce.XDigitalCatalog.Queries;
@@ -23,7 +24,7 @@ public class ChildCategoriesQueryBuilder : CatalogQueryBuilder<ChildCategoriesQu
     public ChildCategoriesQueryBuilder(
         IMediator mediator,
         IAuthorizationService authorizationService,
-        IStoreService storeService,
+        ICrudService<Store> storeService,
         ICurrencyService currencyService,
         ICategoryService categoryService)
         : base(mediator, authorizationService, storeService, currencyService)

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/LoadRelatedCatalogOutlineQueryHandler.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/LoadRelatedCatalogOutlineQueryHandler.cs
@@ -1,16 +1,17 @@
 using System.Threading;
 using System.Threading.Tasks;
 using VirtoCommerce.ExperienceApiModule.Core.Infrastructure;
-using VirtoCommerce.StoreModule.Core.Services;
+using VirtoCommerce.Platform.Core.GenericCrud;
+using VirtoCommerce.StoreModule.Core.Model;
 using VirtoCommerce.XDigitalCatalog.Extensions;
 
 namespace VirtoCommerce.XDigitalCatalog.Queries
 {
     public class LoadRelatedCatalogOutlineQueryHandler : IQueryHandler<LoadRelatedCatalogOutlineQuery, LoadRelatedCatalogOutlineResponse>
     {
-        private readonly IStoreService _storeService;
+        private readonly ICrudService<Store> _storeService;
 
-        public LoadRelatedCatalogOutlineQueryHandler(IStoreService storeService)
+        public LoadRelatedCatalogOutlineQueryHandler(ICrudService<Store> storeService)
         {
             _storeService = storeService;
         }

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/LoadRelatedSlugPathQueryHandler.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/LoadRelatedSlugPathQueryHandler.cs
@@ -1,16 +1,17 @@
 using System.Threading;
 using System.Threading.Tasks;
 using VirtoCommerce.ExperienceApiModule.Core.Infrastructure;
-using VirtoCommerce.StoreModule.Core.Services;
+using VirtoCommerce.Platform.Core.GenericCrud;
+using VirtoCommerce.StoreModule.Core.Model;
 using VirtoCommerce.XDigitalCatalog.Extensions;
 
 namespace VirtoCommerce.XDigitalCatalog.Queries
 {
     public class LoadRelatedSlugPathQueryHandler : IQueryHandler<LoadRelatedSlugPathQuery, LoadRelatedSlugPathResponse>
     {
-        private readonly IStoreService _storeService;
+        private readonly ICrudService<Store> _storeService;
 
-        public LoadRelatedSlugPathQueryHandler(IStoreService storeService)
+        public LoadRelatedSlugPathQueryHandler(ICrudService<Store> storeService)
         {
             _storeService = storeService;
         }

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/SearchCategoryQueryHandler.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/SearchCategoryQueryHandler.cs
@@ -7,10 +7,10 @@ using AutoMapper;
 using VirtoCommerce.ExperienceApiModule.Core.Infrastructure;
 using VirtoCommerce.ExperienceApiModule.Core.Pipelines;
 using VirtoCommerce.ExperienceApiModule.XDigitalCatalog.Index;
+using VirtoCommerce.Platform.Core.GenericCrud;
 using VirtoCommerce.SearchModule.Core.Model;
 using VirtoCommerce.SearchModule.Core.Services;
 using VirtoCommerce.StoreModule.Core.Model;
-using VirtoCommerce.StoreModule.Core.Services;
 
 namespace VirtoCommerce.XDigitalCatalog.Queries
 {
@@ -21,14 +21,14 @@ namespace VirtoCommerce.XDigitalCatalog.Queries
         private readonly IMapper _mapper;
         private readonly ISearchProvider _searchProvider;
         private readonly ISearchPhraseParser _phraseParser;
-        private readonly IStoreService _storeService;
+        private readonly ICrudService<Store> _storeService;
         private readonly IGenericPipelineLauncher _pipeline;
 
         public SearchCategoryQueryHandler(
             ISearchProvider searchProvider
             , IMapper mapper
             , ISearchPhraseParser phraseParser
-            , IStoreService storeService
+            , ICrudService<Store> storeService
             , IGenericPipelineLauncher pipeline)
         {
             _searchProvider = searchProvider;

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Schemas/DigitalCatalogSchema.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Schemas/DigitalCatalogSchema.cs
@@ -15,7 +15,8 @@ using VirtoCommerce.ExperienceApiModule.Core.Extensions;
 using VirtoCommerce.ExperienceApiModule.Core.Helpers;
 using VirtoCommerce.ExperienceApiModule.Core.Infrastructure;
 using VirtoCommerce.Platform.Core.Common;
-using VirtoCommerce.StoreModule.Core.Services;
+using VirtoCommerce.Platform.Core.GenericCrud;
+using VirtoCommerce.StoreModule.Core.Model;
 using VirtoCommerce.XDigitalCatalog.Extensions;
 using VirtoCommerce.XDigitalCatalog.Queries;
 
@@ -26,9 +27,9 @@ namespace VirtoCommerce.XDigitalCatalog.Schemas
         private readonly IMediator _mediator;
         private readonly IDataLoaderContextAccessor _dataLoader;
         private readonly ICurrencyService _currencyService;
-        private readonly IStoreService _storeService;
+        private readonly ICrudService<Store> _storeService;
 
-        public DigitalCatalogSchema(IMediator mediator, IDataLoaderContextAccessor dataLoader, ICurrencyService currencyService, IStoreService storeService)
+        public DigitalCatalogSchema(IMediator mediator, IDataLoaderContextAccessor dataLoader, ICurrencyService currencyService, ICrudService<Store> storeService)
         {
             _mediator = mediator;
             _dataLoader = dataLoader;

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/VirtoCommerce.XDigitalCatalog.csproj
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/VirtoCommerce.XDigitalCatalog.csproj
@@ -12,11 +12,7 @@
     <ItemGroup>
         <PackageReference Include="GraphQL.DataLoader" Version="4.6.0" />
         <PackageReference Include="PipelineNet" Version="0.9.0" />
-        <PackageReference Include="AutoMapper" Version="10.0.0" />
-        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
-        <PackageReference Include="MediatR" Version="8.0.1" />
-        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.0.0" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
         <PackageReference Include="Serialize.Linq" Version="1.8.1" />
         <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.210.0" />
         <PackageReference Include="VirtoCommerce.CartModule.Data" Version="3.210.0" />

--- a/src/VirtoCommerce.ExperienceApiModule.Web/VirtoCommerce.ExperienceApiModule.Web.csproj
+++ b/src/VirtoCommerce.ExperienceApiModule.Web/VirtoCommerce.ExperienceApiModule.Web.csproj
@@ -21,17 +21,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.0.0" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="GraphQL" Version="4.6.0" />
     <PackageReference Include="GraphQL.Authorization" Version="4.0.0" />
     <PackageReference Include="GraphQL.Relay" Version="0.6.2" />
     <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="5.0.2" />
     <PackageReference Include="GraphQL.Server.Transports.AspNetCore.NewtonsoftJson" Version="5.0.2" />
     <PackageReference Include="GraphQL.Server.Ui.Playground" Version="5.0.2" />
-    <PackageReference Include="MediatR" Version="8.0.1" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.13" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.0" />
   </ItemGroup>

--- a/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS.Tests/VirtoCommerce.ExperienceApiModule.XCMS.Tests.csproj
+++ b/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS.Tests/VirtoCommerce.ExperienceApiModule.XCMS.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
     <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/ProcessOrderPaymentCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/ProcessOrderPaymentCommandHandler.cs
@@ -4,8 +4,8 @@ using System.Threading.Tasks;
 using MediatR;
 using VirtoCommerce.OrdersModule.Core.Services;
 using VirtoCommerce.PaymentModule.Model.Requests;
+using VirtoCommerce.Platform.Core.GenericCrud;
 using VirtoCommerce.StoreModule.Core.Model;
-using VirtoCommerce.StoreModule.Core.Services;
 
 namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
 {
@@ -13,13 +13,13 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
     {
         private readonly ICustomerOrderAggregateRepository _customerOrderAggregateRepository;
         private readonly ICustomerOrderService _customerOrderService;
-        private readonly IStoreService _storeService;
+        private readonly ICrudService<Store> _storeService;
 
 
         public ProcessOrderPaymentCommandHandler(
             ICustomerOrderAggregateRepository customerOrderAggregateRepository,
             ICustomerOrderService customerOrderService,
-            IStoreService storeService)
+            ICrudService<Store> storeService)
         {
             _customerOrderAggregateRepository = customerOrderAggregateRepository;
             _customerOrderService = customerOrderService;

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Queries/SearchPaymentsQueryHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Queries/SearchPaymentsQueryHandler.cs
@@ -2,8 +2,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using AutoMapper;
 using VirtoCommerce.ExperienceApiModule.Core.Infrastructure;
+using VirtoCommerce.OrdersModule.Core.Model;
 using VirtoCommerce.OrdersModule.Core.Model.Search;
 using VirtoCommerce.OrdersModule.Core.Services;
+using VirtoCommerce.Platform.Core.GenericCrud;
 using VirtoCommerce.SearchModule.Core.Services;
 
 namespace VirtoCommerce.ExperienceApiModule.XOrder.Queries
@@ -12,7 +14,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Queries
     {
         private readonly IMapper _mapper;
         private readonly ISearchPhraseParser _searchPhraseParser;
-        private readonly IPaymentSearchService _paymentsSearchService;
+        private readonly ISearchService<PaymentSearchCriteria, PaymentSearchResult, PaymentIn> _paymentsSearchService;
 
         public SearchPaymentsQueryHandler(IMapper mapper,
             ISearchPhraseParser searchPhraseParser,
@@ -20,7 +22,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Queries
         {
             _mapper = mapper;
             _searchPhraseParser = searchPhraseParser;
-            _paymentsSearchService = paymentsSearchService;
+            _paymentsSearchService = (ISearchService<PaymentSearchCriteria, PaymentSearchResult, PaymentIn>)paymentsSearchService;
         }
 
         public virtual async Task<PaymentSearchResult> Handle(SearchPaymentsQuery request, CancellationToken cancellationToken)
@@ -31,7 +33,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Queries
                                         .WithPaging(request.Skip, request.Take)
                                         .WithSorting(request.Sort)
                                         .Build();
-            var searchResult = await _paymentsSearchService.SearchPaymentsAsync(searchCriteria);
+            var searchResult = await _paymentsSearchService.SearchAsync(searchCriteria);
             return searchResult;
         }
     }

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/VirtoCommerce.ExperienceApiModule.XOrder.csproj
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/VirtoCommerce.ExperienceApiModule.XOrder.csproj
@@ -10,15 +10,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoMapper" Version="10.0.0" />
-        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
         <PackageReference Include="FluentValidation" Version="10.3.4" />
         <PackageReference Include="GraphQL" Version="4.6.0" />
         <PackageReference Include="GraphQL.DataLoader" Version="4.6.0" />
-        <PackageReference Include="MediatR" Version="8.0.1" />
-        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.13" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
         <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.203.0" />
         <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.220.0" />
         <PackageReference Include="VirtoCommerce.OrdersModule.Data" Version="3.220.0" />

--- a/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/Helpers/XPurchaseMoqHelper.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/Helpers/XPurchaseMoqHelper.cs
@@ -17,16 +17,20 @@ using VirtoCommerce.InventoryModule.Core.Model;
 using VirtoCommerce.MarketingModule.Core.Services;
 using VirtoCommerce.OrdersModule.Core.Services;
 using VirtoCommerce.PaymentModule.Core.Model;
+using VirtoCommerce.PaymentModule.Core.Model.Search;
 using VirtoCommerce.PaymentModule.Core.Services;
 using VirtoCommerce.Platform.Core.GenericCrud;
 using VirtoCommerce.PricingModule.Core.Model;
+using VirtoCommerce.ShippingModule.Core.Model;
+using VirtoCommerce.ShippingModule.Core.Model.Search;
 using VirtoCommerce.ShippingModule.Core.Services;
-using VirtoCommerce.StoreModule.Core.Model;
-using VirtoCommerce.StoreModule.Core.Services;
+using VirtoCommerce.TaxModule.Core.Model;
+using VirtoCommerce.TaxModule.Core.Model.Search;
 using VirtoCommerce.TaxModule.Core.Services;
 using VirtoCommerce.XPurchase.Services;
 using VirtoCommerce.XPurchase.Tests.Helpers.Stubs;
 using VirtoCommerce.XPurchase.Validators;
+using Store = VirtoCommerce.StoreModule.Core.Model.Store;
 
 namespace VirtoCommerce.XPurchase.Tests.Helpers
 {
@@ -41,7 +45,6 @@ namespace VirtoCommerce.XPurchase.Tests.Helpers
         protected readonly Mock<IPaymentMethodsSearchService> _paymentMethodsSearchServiceMock;
         protected readonly Mock<IShippingMethodsSearchService> _shippingMethodsSearchServiceMock;
         protected readonly Mock<IShoppingCartTotalsCalculator> _shoppingCartTotalsCalculatorMock;
-        protected readonly Mock<IStoreService> _storeServiceMock;
         protected readonly Mock<ICrudService<Store>> _crudStoreServiceMock;
         protected readonly Mock<ITaxProviderSearchService> _taxProviderSearchServiceMock;
         protected readonly Mock<IDynamicPropertyUpdaterService> _dynamicPropertyUpdaterService;
@@ -157,21 +160,16 @@ namespace VirtoCommerce.XPurchase.Tests.Helpers
                 .Setup(x => x.EvaluatePromotionAsync(It.IsAny<IEvaluationContext>()))
                 .ReturnsAsync(new StubPromotionResult());
 
-            _paymentMethodsSearchServiceMock = new Mock<IPaymentMethodsSearchService>();
-            _shippingMethodsSearchServiceMock = new Mock<IShippingMethodsSearchService>();
+            _paymentMethodsSearchServiceMock = new Mock<ISearchService<PaymentMethodsSearchCriteria, PaymentMethodsSearchResult, PaymentMethod>>().As<IPaymentMethodsSearchService>();
+            _shippingMethodsSearchServiceMock = new Mock<ISearchService<ShippingMethodsSearchCriteria, ShippingMethodsSearchResult, ShippingMethod>>().As<IShippingMethodsSearchService>();
             _shoppingCartTotalsCalculatorMock = new Mock<IShoppingCartTotalsCalculator>();
-
-            _storeServiceMock = new Mock<IStoreService>();
-            _storeServiceMock
-                .Setup(x => x.GetByIdAsync(It.IsAny<string>(), It.IsAny<string>()))
-                .ReturnsAsync(_fixture.Create<Store>());
 
             _crudStoreServiceMock = new Mock<ICrudService<Store>>();
             _crudStoreServiceMock
                 .Setup(x => x.GetByIdAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(_fixture.Create<Store>());
 
-            _taxProviderSearchServiceMock = new Mock<ITaxProviderSearchService>();
+            _taxProviderSearchServiceMock = new Mock<ISearchService<TaxProviderSearchCriteria, TaxProviderSearchResult, TaxProvider>>().As<ITaxProviderSearchService>();
             _dynamicPropertyUpdaterService = new Mock<IDynamicPropertyUpdaterService>();
 
             _mapperMock = new Mock<IMapper>();

--- a/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/VirtoCommerce.XPurchase.Tests.csproj
+++ b/src/XPurchase/VirtoCommerce.XPurchase.Domain.Tests/VirtoCommerce.XPurchase.Tests.csproj
@@ -18,7 +18,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/XPurchase/VirtoCommerce.XPurchase/Commands/AddCartItemsBulkCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Commands/AddCartItemsBulkCommandHandler.cs
@@ -7,13 +7,14 @@ using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.CatalogModule.Core.Model.Search;
 using VirtoCommerce.CatalogModule.Core.Search;
 using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.GenericCrud;
 
 namespace VirtoCommerce.XPurchase.Commands
 {
     public class AddCartItemsBulkCommandHandler : IRequestHandler<AddCartItemsBulkCommand, BulkCartResult>
     {
         private readonly ICartAggregateRepository _cartAggrRepository;
-        private readonly IProductSearchService _productSearchService;
+        private readonly ISearchService<ProductSearchCriteria, ProductSearchResult, CatalogProduct> _productSearchService;
         private readonly IMediator _mediator;
 
         public AddCartItemsBulkCommandHandler(
@@ -87,7 +88,7 @@ namespace VirtoCommerce.XPurchase.Commands
                 ResponseGroup = ItemResponseGroup.ItemInfo.ToString(),
             };
 
-            var searchProductResult = await _productSearchService.SearchProductsAsync(productSearchRequest);
+            var searchProductResult = await _productSearchService.SearchAsync(productSearchRequest);
             return searchProductResult.Results;
         }
     }

--- a/src/XPurchase/VirtoCommerce.XPurchase/Schemas/PurchaseSchema.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Schemas/PurchaseSchema.cs
@@ -1411,7 +1411,7 @@ namespace VirtoCommerce.XPurchase.Schemas
 
         private async Task CheckAuthAsyncByCartIds(IResolveFieldContext context, List<string> cartIds)
         {
-            var carts = await _cartService.GetByIdsAsync(cartIds, CartResponseGroup.Default.ToString());
+            var carts = await _cartService.GetAsync(cartIds, CartResponseGroup.Default.ToString());
 
             await AuthorizeAsync(context, carts);
         }

--- a/src/XPurchase/VirtoCommerce.XPurchase/Services/CartAvailMethodsService.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Services/CartAvailMethodsService.cs
@@ -8,6 +8,7 @@ using VirtoCommerce.PaymentModule.Core.Model;
 using VirtoCommerce.PaymentModule.Core.Model.Search;
 using VirtoCommerce.PaymentModule.Core.Services;
 using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.GenericCrud;
 using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.ShippingModule.Core.Model;
 using VirtoCommerce.ShippingModule.Core.Model.Search;
@@ -22,9 +23,9 @@ namespace VirtoCommerce.XPurchase.Services
 {
     public class CartAvailMethodsService : ICartAvailMethodsService
     {
-        private readonly IPaymentMethodsSearchService _paymentMethodsSearchService;
-        private readonly ITaxProviderSearchService _taxProviderSearchService;
-        private readonly IShippingMethodsSearchService _shippingMethodsSearchService;
+        private readonly ISearchService<PaymentMethodsSearchCriteria, PaymentMethodsSearchResult, PaymentMethod> _paymentMethodsSearchService;
+        private readonly ISearchService<TaxProviderSearchCriteria, TaxProviderSearchResult, TaxProvider> _taxProviderSearchService;
+        private readonly ISearchService<ShippingMethodsSearchCriteria, ShippingMethodsSearchResult, ShippingMethod> _shippingMethodsSearchService;
         private readonly ICartProductService _cartProductService;
 
         private readonly IMapper _mapper;
@@ -37,9 +38,9 @@ namespace VirtoCommerce.XPurchase.Services
             ICartProductService cartProductService,
             IMapper mapper)
         {
-            _paymentMethodsSearchService = paymentMethodsSearchService;
-            _shippingMethodsSearchService = shippingMethodsSearchService;
-            _taxProviderSearchService = taxProviderSearchService;
+            _paymentMethodsSearchService = (ISearchService<PaymentMethodsSearchCriteria, PaymentMethodsSearchResult, PaymentMethod>)paymentMethodsSearchService;
+            _shippingMethodsSearchService = (ISearchService<ShippingMethodsSearchCriteria, ShippingMethodsSearchResult, ShippingMethod>)shippingMethodsSearchService;
+            _taxProviderSearchService = (ISearchService<TaxProviderSearchCriteria, TaxProviderSearchResult, TaxProvider>)taxProviderSearchService;
             _cartProductService = cartProductService;
             _mapper = mapper;
         }
@@ -61,7 +62,7 @@ namespace VirtoCommerce.XPurchase.Services
                 StoreId = cartAggr.Store?.Id
             };
 
-            var activeAvailableShippingMethods = (await _shippingMethodsSearchService.SearchShippingMethodsAsync(criteria)).Results;
+            var activeAvailableShippingMethods = (await _shippingMethodsSearchService.SearchAsync(criteria)).Results;
 
             var availableShippingRates = activeAvailableShippingMethods
                 .SelectMany(x => x.CalculateRates(shippingEvaluationContext))
@@ -113,7 +114,7 @@ namespace VirtoCommerce.XPurchase.Services
                 StoreId = cartAggr.Store?.Id,
             };
 
-            var result = await _paymentMethodsSearchService.SearchPaymentMethodsAsync(criteria);
+            var result = await _paymentMethodsSearchService.SearchAsync(criteria);
             if (result.Results.IsNullOrEmpty())
             {
                 return Enumerable.Empty<PaymentMethod>();
@@ -201,7 +202,7 @@ namespace VirtoCommerce.XPurchase.Services
 
         protected async Task<TaxProvider> GetActiveTaxProviderAsync(string storeId)
         {
-            var storeTaxProviders = await _taxProviderSearchService.SearchTaxProvidersAsync(new TaxProviderSearchCriteria
+            var storeTaxProviders = await _taxProviderSearchService.SearchAsync(new TaxProviderSearchCriteria
             {
                 StoreIds = new[] { storeId }
             });

--- a/src/XPurchase/VirtoCommerce.XPurchase/VirtoCommerce.XPurchase.csproj
+++ b/src/XPurchase/VirtoCommerce.XPurchase/VirtoCommerce.XPurchase.csproj
@@ -13,11 +13,7 @@
         <PackageReference Include="GraphQL.DataLoader" Version="4.6.0" />
         <PackageReference Include="PipelineNet" Version="0.9.0" />
         <PackageReference Include="GraphQL" Version="4.6.0" />
-        <PackageReference Include="MediatR" Version="8.0.1" />
-        <PackageReference Include="AutoMapper" Version="10.0.0" />
-        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.1" />
-        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.0.0" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
         <PackageReference Include="VirtoCommerce.CartModule.Data" Version="3.210.0" />
         <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.203.0" />
         <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.205.0" />

--- a/tests/VirtoCommerce.ExperienceApiModule.Tests/VirtoCommerce.ExperienceApiModule.Tests.csproj
+++ b/tests/VirtoCommerce.ExperienceApiModule.Tests/VirtoCommerce.ExperienceApiModule.Tests.csproj
@@ -12,11 +12,10 @@
 
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.11.0" />
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="MediatR" Version="8.0.1" />
         <PackageReference Include="GraphQL" Version="4.6.0" />
         <PackageReference Include="GraphQL.Relay" Version="0.6.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />

--- a/tests/VirtoCommerce.ExperienceApiModule.XOrder.Tests/Handlers/CreateOrderFromCartCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.ExperienceApiModule.XOrder.Tests/Handlers/CreateOrderFromCartCommandHandlerTests.cs
@@ -6,7 +6,6 @@ using AutoFixture;
 using AutoMapper;
 using GraphQL;
 using Moq;
-using VirtoCommerce.CartModule.Core.Model;
 using VirtoCommerce.CartModule.Core.Services;
 using VirtoCommerce.CustomerModule.Core.Model;
 using VirtoCommerce.ExperienceApiModule.Core.Services;
@@ -15,13 +14,15 @@ using VirtoCommerce.ExperienceApiModule.XOrder.Tests.Helpers;
 using VirtoCommerce.MarketingModule.Core.Services;
 using VirtoCommerce.OrdersModule.Core.Services;
 using VirtoCommerce.Platform.Core.GenericCrud;
-using VirtoCommerce.StoreModule.Core.Model;
+using VirtoCommerce.TaxModule.Core.Model;
+using VirtoCommerce.TaxModule.Core.Model.Search;
 using VirtoCommerce.TaxModule.Core.Services;
 using VirtoCommerce.XPurchase;
 using VirtoCommerce.XPurchase.Services;
 using VirtoCommerce.XPurchase.Validators;
 using Xunit;
 using Cart = VirtoCommerce.CartModule.Core.Model;
+using Store = VirtoCommerce.StoreModule.Core.Model.Store;
 
 namespace VirtoCommerce.ExperienceApiModule.XOrder.Tests.Handlers
 {
@@ -33,7 +34,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Tests.Handlers
             // Arrange
             var cart = _fixture.Create<Cart.ShoppingCart>();
             var lineItem = _fixture.Create<Cart.LineItem>();
-            cart.Items = new List<LineItem>() { lineItem };
+            cart.Items = new List<Cart.LineItem>() { lineItem };
 
             var cartAggregate = GetCartAggregateMock(cart);
 
@@ -66,12 +67,12 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Tests.Handlers
             await Assert.ThrowsAsync<ExecutionError>(() => handler.Handle(request, CancellationToken.None));
         }
 
-        private static CartAggregate GetCartAggregateMock(ShoppingCart cart)
+        private static CartAggregate GetCartAggregateMock(Cart.ShoppingCart cart)
         {
             var cartAggregate = new CartAggregate(
                 Mock.Of<IMarketingPromoEvaluator>(),
                 Mock.Of<IShoppingCartTotalsCalculator>(),
-                Mock.Of<ITaxProviderSearchService>(),
+                new Mock<ISearchService<TaxProviderSearchCriteria, TaxProviderSearchResult, TaxProvider>>().As<ITaxProviderSearchService>().Object,
                 Mock.Of<ICartProductService>(),
                 Mock.Of<IDynamicPropertyUpdaterService>(),
                 Mock.Of<IMapper>(),
@@ -87,11 +88,11 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Tests.Handlers
             return cartAggregate;
         }
 
-        public class ShoppingCartServiceStub : ICrudService<ShoppingCart>, IShoppingCartService
+        public class ShoppingCartServiceStub : ICrudService<Cart.ShoppingCart>, IShoppingCartService
         {
-            private readonly ShoppingCart _cart;
+            private readonly Cart.ShoppingCart _cart;
 
-            public ShoppingCartServiceStub(ShoppingCart cart)
+            public ShoppingCartServiceStub(Cart.ShoppingCart cart)
             {
                 _cart = cart;
             }
@@ -106,32 +107,32 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Tests.Handlers
                 throw new NotImplementedException();
             }
 
-            public Task<IReadOnlyCollection<ShoppingCart>> GetAsync(List<string> ids, string responseGroup = null)
+            public Task<IReadOnlyCollection<Cart.ShoppingCart>> GetAsync(List<string> ids, string responseGroup = null)
             {
                 throw new NotImplementedException();
             }
 
-            public Task<ShoppingCart> GetByIdAsync(string cartId, string responseGroup = null)
+            public Task<Cart.ShoppingCart> GetByIdAsync(string id, string responseGroup = null)
             {
                 return Task.FromResult(_cart);
             }
 
-            public Task<ShoppingCart[]> GetByIdsAsync(string[] cartIds, string responseGroup = null)
+            public Task<Cart.ShoppingCart[]> GetByIdsAsync(string[] cartIds, string responseGroup = null)
             {
                 throw new NotImplementedException();
             }
 
-            public Task<IEnumerable<ShoppingCart>> GetByIdsAsync(IEnumerable<string> ids, string responseGroup = null)
+            public Task<IEnumerable<Cart.ShoppingCart>> GetByIdsAsync(IEnumerable<string> ids, string responseGroup = null)
             {
                 throw new NotImplementedException();
             }
 
-            public Task SaveChangesAsync(ShoppingCart[] carts)
+            public Task SaveChangesAsync(Cart.ShoppingCart[] carts)
             {
                 throw new NotImplementedException();
             }
 
-            public Task SaveChangesAsync(IEnumerable<ShoppingCart> models)
+            public Task SaveChangesAsync(IEnumerable<Cart.ShoppingCart> models)
             {
                 throw new NotImplementedException();
             }

--- a/tests/VirtoCommerce.ExperienceApiModule.XOrder.Tests/VirtoCommerce.ExperienceApiModule.XOrder.Tests.csproj
+++ b/tests/VirtoCommerce.ExperienceApiModule.XOrder.Tests/VirtoCommerce.ExperienceApiModule.XOrder.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/VirtoCommerce.XDigitalCatalog.Tests/Middlewares/EvalProductsTaxMiddlewareTest.cs
+++ b/tests/VirtoCommerce.XDigitalCatalog.Tests/Middlewares/EvalProductsTaxMiddlewareTest.cs
@@ -8,6 +8,7 @@ using VirtoCommerce.CoreModule.Core.Common;
 using VirtoCommerce.CoreModule.Core.Currency;
 using VirtoCommerce.ExperienceApiModule.Core.Models;
 using VirtoCommerce.ExperienceApiModule.Core.Pipelines;
+using VirtoCommerce.Platform.Core.GenericCrud;
 using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.TaxModule.Core.Model;
 using VirtoCommerce.TaxModule.Core.Model.Search;
@@ -25,7 +26,7 @@ namespace VirtoCommerce.XDigitalCatalog.Tests.Middlewares
         {
             // Arrange
             var mapper = new Mock<IMapper>();
-            var taxProviderSearchService = new Mock<ITaxProviderSearchService>();
+            var taxProviderSearchService = new Mock<ISearchService<TaxProviderSearchCriteria, TaxProviderSearchResult, TaxProvider>>().As<ITaxProviderSearchService>();
             var genericPipelineLauncher = new Mock<IGenericPipelineLauncher>();
 
             var evalProductsTaxMiddleware = new EvalProductsTaxMiddleware(mapper.Object, taxProviderSearchService.Object, genericPipelineLauncher.Object);
@@ -41,7 +42,9 @@ namespace VirtoCommerce.XDigitalCatalog.Tests.Middlewares
             evalProductsTaxMiddleware.Run(response, resp => Task.CompletedTask);
 
             // Assert
-            taxProviderSearchService.Verify(x => x.SearchTaxProvidersAsync(It.IsAny<TaxProviderSearchCriteria>()), Times.Never);
+            taxProviderSearchService
+                .As<ISearchService<TaxProviderSearchCriteria, TaxProviderSearchResult, TaxProvider>>()
+                .Verify(x => x.SearchAsync(It.IsAny<TaxProviderSearchCriteria>()), Times.Never);
         }
 
         [Fact]
@@ -50,7 +53,9 @@ namespace VirtoCommerce.XDigitalCatalog.Tests.Middlewares
             // Arrange
             var mapper = new Mock<IMapper>();
             var taxProviderSearchService = new Mock<ITaxProviderSearchService>();
-            taxProviderSearchService.Setup(x => x.SearchTaxProvidersAsync(It.IsAny<TaxProviderSearchCriteria>()))
+            taxProviderSearchService
+                .As<ISearchService<TaxProviderSearchCriteria, TaxProviderSearchResult, TaxProvider>>()
+                .Setup(x => x.SearchAsync(It.IsAny<TaxProviderSearchCriteria>()))
                 .ReturnsAsync(() => new TaxProviderSearchResult()
                 {
                     TotalCount = 0,
@@ -77,7 +82,9 @@ namespace VirtoCommerce.XDigitalCatalog.Tests.Middlewares
 
             // Assert
             action.Should().NotThrow();
-            taxProviderSearchService.Verify(x => x.SearchTaxProvidersAsync(It.IsAny<TaxProviderSearchCriteria>()), Times.Once);
+            taxProviderSearchService
+                .As<ISearchService<TaxProviderSearchCriteria, TaxProviderSearchResult, TaxProvider>>()
+                .Verify(x => x.SearchAsync(It.IsAny<TaxProviderSearchCriteria>()), Times.Once);
         }
 
         [Fact]
@@ -89,7 +96,9 @@ namespace VirtoCommerce.XDigitalCatalog.Tests.Middlewares
 
             var mapper = new Mock<IMapper>();
             var taxProviderSearchService = new Mock<ITaxProviderSearchService>();
-            taxProviderSearchService.Setup(x => x.SearchTaxProvidersAsync(It.IsAny<TaxProviderSearchCriteria>()))
+            taxProviderSearchService
+                .As<ISearchService<TaxProviderSearchCriteria, TaxProviderSearchResult, TaxProvider>>()
+                .Setup(x => x.SearchAsync(It.IsAny<TaxProviderSearchCriteria>()))
                 .ReturnsAsync(() => new TaxProviderSearchResult()
                 {
                     TotalCount = 1,
@@ -119,7 +128,9 @@ namespace VirtoCommerce.XDigitalCatalog.Tests.Middlewares
 
             // Assert
             action.Should().NotThrow();
-            taxProviderSearchService.Verify(x => x.SearchTaxProvidersAsync(It.IsAny<TaxProviderSearchCriteria>()), Times.Once);
+            taxProviderSearchService
+                .As<ISearchService<TaxProviderSearchCriteria, TaxProviderSearchResult, TaxProvider>>()
+                .Verify(x => x.SearchAsync(It.IsAny<TaxProviderSearchCriteria>()), Times.Once);
             taxProvider.Verify(x => x.CalculateRates(It.IsAny<TaxEvaluationContext>()), Times.Once);
         }
 
@@ -146,7 +157,9 @@ namespace VirtoCommerce.XDigitalCatalog.Tests.Middlewares
 
             var mapper = new Mock<IMapper>();
             var taxProviderSearchService = new Mock<ITaxProviderSearchService>();
-            taxProviderSearchService.Setup(x => x.SearchTaxProvidersAsync(It.IsAny<TaxProviderSearchCriteria>()))
+            taxProviderSearchService
+                .As<ISearchService<TaxProviderSearchCriteria, TaxProviderSearchResult, TaxProvider>>()
+                .Setup(x => x.SearchAsync(It.IsAny<TaxProviderSearchCriteria>()))
                 .ReturnsAsync(() => new TaxProviderSearchResult()
                 {
                     TotalCount = 0,
@@ -179,7 +192,9 @@ namespace VirtoCommerce.XDigitalCatalog.Tests.Middlewares
 
             // Assert
             action.Should().NotThrow();
-            taxProviderSearchService.Verify(x => x.SearchTaxProvidersAsync(It.IsAny<TaxProviderSearchCriteria>()), Times.Once);
+            taxProviderSearchService
+                .As<ISearchService<TaxProviderSearchCriteria, TaxProviderSearchResult, TaxProvider>>()
+                .Verify(x => x.SearchAsync(It.IsAny<TaxProviderSearchCriteria>()), Times.Once);
             taxProvider.Verify(x => x.CalculateRates(It.IsAny<TaxEvaluationContext>()), Times.Once);
             productPrice.TaxPercentRate.Should().Be(0.5m);
         }

--- a/tests/VirtoCommerce.XDigitalCatalog.Tests/VirtoCommerce.XDigitalCatalog.Tests.csproj
+++ b/tests/VirtoCommerce.XDigitalCatalog.Tests/VirtoCommerce.XDigitalCatalog.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
## Description
Bump NuGet versions
- AutoMapper 10.1.1
- Mediatr 9.0.0

Remove using the obsolete interface for services
## References
### QA-test:
### Jira-link:
### Artifact URL:
