### PR TITLE
PT-11736: wrong price in the cart if product has several price lists

### DIFF
--- a/src/XPurchase/VirtoCommerce.XPurchase/Services/CartProductService.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Services/CartProductService.cs
@@ -71,7 +71,7 @@ namespace VirtoCommerce.XPurchase.Services
             if (aggregate is null || ids.IsNullOrEmpty())
                 return new List<CartProduct>();
 
-            var cartProducts = await GetCartProductsAsync(ids, aggregate.Store.Id);
+            var cartProducts = await GetCartProductsAsync(ids, aggregate.Store.Id, aggregate.Cart.Currency);
 
             var productsToLoadDependencies = cartProducts.Where(x => x.LoadDependencies).ToList();
             if (productsToLoadDependencies.Any())
@@ -98,11 +98,12 @@ namespace VirtoCommerce.XPurchase.Services
         /// </summary>
         /// <param name="catalogProducts">Products from the catalog</param>
         /// <returns>List of <see cref="CartProduct"/>s</returns>
-        protected async virtual Task<List<CartProduct>> GetCartProductsAsync(IEnumerable<string> ids, string storeId)
+        protected async virtual Task<List<CartProduct>> GetCartProductsAsync(IEnumerable<string> ids, string storeId, string currencyCode)
         {
             var productsQuery = new LoadProductsQuery
             {
                 StoreId = storeId,
+                CurrencyCode = currencyCode,
                 ObjectIds = ids.ToArray(),
                 IncludeFields = IncludeFields,
                 EvaluatePromotions = false, // Promotions will be applied on the line item level


### PR DESCRIPTION
## Description
fix: wrong price in the cart if product has several price lists and store is muti-currency.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-11736
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.304.0-pr-392-5bce.zip
