### PR TITLE
PT-11539: Cart Language Code never changed after creation

### DIFF
--- a/src/XPurchase/VirtoCommerce.XPurchase/CartAggregateRepository.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/CartAggregateRepository.cs
@@ -130,9 +130,16 @@ namespace VirtoCommerce.XPurchase
             {
                 throw new OperationCanceledException($"store with id {cart.StoreId} not found");
             }
+
+            // Set Default Currency 
             if (string.IsNullOrEmpty(cart.Currency))
             {
                 cart.Currency = store.DefaultCurrency;
+            }
+            // Actualize Cart Language From Context
+            if (!string.IsNullOrEmpty(language) && cart.LanguageCode != language)
+            {
+                cart.LanguageCode = language;
             }
 
             var currency = allCurrencies.GetCurrencyForLanguage(cart.Currency, language ?? store.DefaultLanguage);


### PR DESCRIPTION
## Description
fix: Cart Language Code never changed after creation. After the fix, cart Cart Language Code is actualized from mutation context.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-11539
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.304.0-pr-393-4462.zip
