### PR TITLE
PT-11605: XAPI returns Zero Products if Catalog Personalization Module is not installed.

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Middlewares/EvalSearchRequestUserGroupsMiddleware.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Middlewares/EvalSearchRequestUserGroupsMiddleware.cs
@@ -50,7 +50,7 @@ namespace VirtoCommerce.XDigitalCatalog.Middlewares
 
         private bool IsCatalogPersonalizationModuleInstalled()
         {
-            return _moduleCatalog.Modules.FirstOrDefault(m => m.ModuleName == "VirtoCommerce.CatalogPersonalization") != null;
+            return _moduleCatalog.Modules.Any(m => m.ModuleName == "VirtoCommerce.CatalogPersonalization");
         }
 
         private async Task<IList<string>> GetUserGroupsInheritedAsync(Contact contact)

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Middlewares/EvalSearchRequestUserGroupsMiddleware.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Middlewares/EvalSearchRequestUserGroupsMiddleware.cs
@@ -27,6 +27,9 @@ namespace VirtoCommerce.XDigitalCatalog.Middlewares
 
         public async Task Run(IndexSearchRequestBuilder parameter, Func<IndexSearchRequestBuilder, Task> next)
         {
+            /// Please note that this solution is temporary. In the upcoming release, we are actively working on resolving this issue by introducing optional dependencies.
+            /// With optional dependencies, the XAPI will seamlessly integrate with the Catalog Personalization Module if it is installed, and gracefully handle scenarios where the module is not present.
+            /// This approach will provide a more robust and flexible solution, enabling smoother interactions between the XAPI and the Catalog Personalization Module.
             if (IsCatalogPersonalizationModuleInstalled())
             {
                 var userGroups = new List<string> { "__any" };
@@ -48,6 +51,11 @@ namespace VirtoCommerce.XDigitalCatalog.Middlewares
             await next(parameter);
         }
 
+
+        /// <summary>
+        /// Checks if the Catalog Personalization Module is installed.
+        /// </summary>
+        /// <returns></returns>
         private bool IsCatalogPersonalizationModuleInstalled()
         {
             return _moduleCatalog.Modules.Any(m => m.ModuleName == "VirtoCommerce.CatalogPersonalization");

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Middlewares/EvalSearchRequestUserGroupsMiddleware.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Middlewares/EvalSearchRequestUserGroupsMiddleware.cs
@@ -8,6 +8,7 @@ using VirtoCommerce.CustomerModule.Core.Services;
 using VirtoCommerce.ExperienceApiModule.Core;
 using VirtoCommerce.ExperienceApiModule.XDigitalCatalog.Index;
 using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Modularity;
 
 namespace VirtoCommerce.XDigitalCatalog.Middlewares
 {
@@ -15,31 +16,41 @@ namespace VirtoCommerce.XDigitalCatalog.Middlewares
     {
         protected readonly IMemberResolver _memberResolver;
         protected readonly IMemberService _memberService;
+        protected readonly IModuleCatalog _moduleCatalog;
 
-        public EvalSearchRequestUserGroupsMiddleware(IMemberResolver memberResolver, IMemberService memberService)
+        public EvalSearchRequestUserGroupsMiddleware(IMemberResolver memberResolver, IMemberService memberService, IModuleCatalog moduleCatalog)
         {
             _memberResolver = memberResolver;
             _memberService = memberService;
+            _moduleCatalog = moduleCatalog;
         }
 
         public async Task Run(IndexSearchRequestBuilder parameter, Func<IndexSearchRequestBuilder, Task> next)
         {
-            var userGroups = new List<string> { "__any" };
-
-            if (!string.IsNullOrEmpty(parameter?.UserId) && !AnonymousUser.UserName.EqualsInvariant(parameter.UserId))
+            if (IsCatalogPersonalizationModuleInstalled())
             {
-                var member = await _memberResolver.ResolveMemberByIdAsync(parameter.UserId);
+                var userGroups = new List<string> { "__any" };
 
-                if (member is Contact contact)
+                if (!string.IsNullOrEmpty(parameter?.UserId) && !AnonymousUser.UserName.EqualsInvariant(parameter.UserId))
                 {
-                    userGroups.AddRange(await GetUserGroupsInheritedAsync(contact));
+                    var member = await _memberResolver.ResolveMemberByIdAsync(parameter.UserId);
+
+                    if (member is Contact contact)
+                    {
+                        userGroups.AddRange(await GetUserGroupsInheritedAsync(contact));
+                    }
                 }
+
+                var userGroupsValue = string.Join(',', userGroups);
+                parameter?.AddTerms(new[] { $"user_groups:{userGroupsValue}" });
             }
 
-            var userGroupsValue = string.Join(',', userGroups);
-            parameter?.AddTerms(new[] { $"user_groups:{userGroupsValue}" });
-
             await next(parameter);
+        }
+
+        private bool IsCatalogPersonalizationModuleInstalled()
+        {
+            return _moduleCatalog.Modules.FirstOrDefault(m => m.ModuleName == "VirtoCommerce.CatalogPersonalization") != null;
         }
 
         private async Task<IList<string>> GetUserGroupsInheritedAsync(Contact contact)


### PR DESCRIPTION
## Description
fix: XAPI returns Zero Products if Catalog Personalization Module is not installed. With this fix, a check has been implemented to determine if the Catalog Personalization Module is installed. If it is installed, the fix adds user groups as a filter criterion when retrieving products through the XAPI. This ensures that the product response is accurate and includes only the relevant products based on the user's group affiliations.

## References
### QA-test:
### Jira-link:



https://virtocommerce.atlassian.net/browse/PT-11605
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.328.0-pr-422-8d5d.zip
