### PR TITLE
PT-14534: NullReferenceException when user get product without properties

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Middlewares/EnsurePropertyMetadataLoadedMiddleware.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Middlewares/EnsurePropertyMetadataLoadedMiddleware.cs
@@ -38,6 +38,7 @@ namespace VirtoCommerce.XDigitalCatalog.Middlewares
             if (responseGroup.HasFlag(ExpProductResponseGroup.LoadPropertyMetadata))
             {
                 var productProperties = parameter.Results
+                    .Where(x => x.IndexedProduct is not null && x.IndexedProduct.Properties is not null)
                     .SelectMany(x => x.IndexedProduct.Properties)
                     .Where(property => property?.Id is not null)
                     .ToArray();


### PR DESCRIPTION
## Description
fix: NullReferenceException when user get product without properties.

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/PT-14534
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.433.0-pr-489-14c1.zip
