### PR TITLE
PT-14367: comment, coupon, and purchase order number are not cleared after order creation

### DIFF
--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/CreateOrderFromCartCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/CreateOrderFromCartCommandHandler.cs
@@ -53,6 +53,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
             cartAggregate.Cart.Coupons?.Clear();
 
             cartAggregate.Cart.PurchaseOrderNumber = string.Empty;
+            cartAggregate.Cart.Comment = string.Empty;
             cartAggregate.Cart.Description = string.Empty;
             cartAggregate.Cart.Coupon = string.Empty;
 

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/CreateOrderFromCartCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/CreateOrderFromCartCommandHandler.cs
@@ -47,9 +47,14 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
             var selectedLineItemIds = cartAggregate.SelectedLineItems.Select(x => x.Id).ToArray();
             await cartAggregate.RemoveItemsAsync(selectedLineItemIds);
 
-            // clear payments and shipments
+            // clear cart
             cartAggregate.Cart.Shipments?.Clear();
             cartAggregate.Cart.Payments?.Clear();
+            cartAggregate.Cart.Coupons?.Clear();
+
+            cartAggregate.Cart.PurchaseOrderNumber = string.Empty;
+            cartAggregate.Cart.Description = string.Empty;
+            cartAggregate.Cart.Coupon = string.Empty;
 
             await _cartRepository.SaveAsync(cartAggregate);
 

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/CreateOrderFromCartCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/CreateOrderFromCartCommandHandler.cs
@@ -54,7 +54,6 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
 
             cartAggregate.Cart.PurchaseOrderNumber = string.Empty;
             cartAggregate.Cart.Comment = string.Empty;
-            cartAggregate.Cart.Description = string.Empty;
             cartAggregate.Cart.Coupon = string.Empty;
 
             await _cartRepository.SaveAsync(cartAggregate);


### PR DESCRIPTION
## Description
fix: The comment, coupon, and Purchase Order number are not cleared after order creation

## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/PT-14367
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.438.0-pr-494-0951.zip
