### PR TITLE
PT-14834: clear cart dynamic properties

### DIFF
--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/CreateOrderFromCartCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/CreateOrderFromCartCommandHandler.cs
@@ -55,6 +55,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
             cartAggregate.Cart.PurchaseOrderNumber = string.Empty;
             cartAggregate.Cart.Comment = string.Empty;
             cartAggregate.Cart.Coupon = string.Empty;
+            cartAggregate.Cart.DynamicProperties.Clear();
 
             await _cartRepository.SaveAsync(cartAggregate);
 

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/CreateOrderFromCartCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/Commands/CreateOrderFromCartCommandHandler.cs
@@ -55,7 +55,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder.Commands
             cartAggregate.Cart.PurchaseOrderNumber = string.Empty;
             cartAggregate.Cart.Comment = string.Empty;
             cartAggregate.Cart.Coupon = string.Empty;
-            cartAggregate.Cart.DynamicProperties.Clear();
+            cartAggregate.Cart.DynamicProperties?.Clear();
 
             await _cartRepository.SaveAsync(cartAggregate);
 

--- a/src/XPurchase/VirtoCommerce.XPurchase/CartAggregate.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/CartAggregate.cs
@@ -421,6 +421,7 @@ namespace VirtoCommerce.XPurchase
 
             Cart.Coupons.Clear();
             Cart.Items.Clear();
+            Cart.DynamicProperties.Clear();
 
             return Task.FromResult(this);
         }

--- a/src/XPurchase/VirtoCommerce.XPurchase/CartAggregate.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/CartAggregate.cs
@@ -421,7 +421,7 @@ namespace VirtoCommerce.XPurchase
 
             Cart.Coupons.Clear();
             Cart.Items.Clear();
-            Cart.DynamicProperties.Clear();
+            Cart.DynamicProperties?.Clear();
 
             return Task.FromResult(this);
         }


### PR DESCRIPTION
## Description
fix: DynamicProperties still exist in cart after clearCart or createOrderFrom cart mutations

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-14834
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.444.0-pr-500-99e2.zip
