### PR TITLE
PT-14888,PT-14894: add custom validation rules

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.Core/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Extensions/GraphQLBuilderExtensions.cs
@@ -1,0 +1,16 @@
+using GraphQL.Server;
+using GraphQL.Validation;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace VirtoCommerce.ExperienceApiModule.Core.Extensions
+{
+    public static class GraphQLBuilderExtensions
+    {
+        public static IGraphQLBuilder AddCustomValidationRule<TRule>(this IGraphQLBuilder builder) where TRule : class, IValidationRule
+        {
+            builder.Services.AddTransient<IValidationRule, TRule>();
+
+            return builder;
+        }
+    }
+}

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Extensions/GraphQLBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using GraphQL.Server;
 using GraphQL.Validation;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,6 +10,13 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Extensions
         public static IGraphQLBuilder AddCustomValidationRule<TRule>(this IGraphQLBuilder builder) where TRule : class, IValidationRule
         {
             builder.Services.AddTransient<IValidationRule, TRule>();
+
+            return builder;
+        }
+
+        public static IGraphQLBuilder AddCustomValidationRule(this IGraphQLBuilder builder, Type ruleType)
+        {
+            builder.Services.AddTransient(typeof(IValidationRule), ruleType);
 
             return builder;
         }

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Infrastructure/Validation/ContentTypeValidationRule.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Infrastructure/Validation/ContentTypeValidationRule.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using GraphQL.Server.Transports.AspNetCore;
+using GraphQL.Validation;
+using Microsoft.AspNetCore.Http;
+
+namespace VirtoCommerce.ExperienceApiModule.Core.Infrastructure.Validation
+{
+    public class ContentTypeValidationRule : IValidationRule
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public ContentTypeValidationRule(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public virtual Task<INodeVisitor> ValidateAsync(ValidationContext context)
+        {
+            var contentType = _httpContextAccessor?.HttpContext?.Request?.ContentType;
+            if (contentType != MediaType.JSON && contentType != MediaType.GRAPH_QL)
+            {
+                context.ReportError(new ValidationError(string.Empty, string.Empty, "Non-supported media type."));
+            }
+
+            return default;
+        }
+    }
+}

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Infrastructure/Validation/CustomFieldsOnCorrectType.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Infrastructure/Validation/CustomFieldsOnCorrectType.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using GraphQL;
+using GraphQL.Language.AST;
+using GraphQL.Validation;
+using GraphQL.Validation.Errors;
+
+namespace VirtoCommerce.ExperienceApiModule.Core.Infrastructure.Validation
+{
+    public class CustomFieldsOnCorrectType : IValidationRule
+    {
+        public virtual async Task<INodeVisitor> ValidateAsync(ValidationContext context)
+        {
+            var visitor = new NodeVisitors(new MatchingNodeVisitor<Field>((node, context) => Validate(node, context)));
+
+            return await Task.FromResult(visitor);
+        }
+
+        protected virtual void Validate(Field node, ValidationContext context)
+        {
+            var type = context.TypeInfo.GetParentType()?.GetNamedType();
+            if (type != null)
+            {
+                var field = context.TypeInfo.GetFieldDef();
+                if (field == null)
+                {
+                    context.ReportError(new FieldsOnCorrectTypeError(context, node, type, suggestedTypeNames: null, suggestedFieldNames: null));
+                }
+            }
+        }
+    }
+}

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Infrastructure/Validation/CustomKnownArgumentNames.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Infrastructure/Validation/CustomKnownArgumentNames.cs
@@ -31,7 +31,7 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Infrastructure.Validation
                                 var fieldArgument = field.Arguments?.Find(node.Name);
                                 if (fieldArgument == null)
                                 {
-                                    var fieldClone = new FieldType { Name = fieldArgument.Name };
+                                    var fieldClone = new FieldType { Name = field.Name };
                                     var parentType = context.TypeInfo.GetParentType() ?? throw new InvalidOperationException("Parent type must not be null.");
                                     context.ReportError(new KnownArgumentNamesError(context, node, fieldClone, parentType));
                                 }

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Infrastructure/Validation/CustomKnownArgumentNames.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Infrastructure/Validation/CustomKnownArgumentNames.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Threading.Tasks;
+using GraphQL.Language.AST;
+using GraphQL.Types;
+using GraphQL.Validation;
+using GraphQL.Validation.Errors;
+
+namespace VirtoCommerce.ExperienceApiModule.Core.Infrastructure.Validation
+{
+    public partial class CustomRules
+    {
+        public class CustomKnownArgumentNames : IValidationRule
+        {
+            public virtual async Task<INodeVisitor> ValidateAsync(ValidationContext context)
+            {
+                var visitor = new NodeVisitors(new MatchingNodeVisitor<Argument>((node, context) => Validate(node, context)));
+
+                return await Task.FromResult(visitor);
+            }
+
+            protected virtual void Validate(Argument node, ValidationContext context)
+            {
+                var argument = context.TypeInfo.GetAncestor(2);
+                switch (argument)
+                {
+                    case Field:
+                        {
+                            var field = context.TypeInfo.GetFieldDef();
+                            if (field != null)
+                            {
+                                var fieldArgument = field.Arguments?.Find(node.Name);
+                                if (fieldArgument == null)
+                                {
+                                    var fieldClone = new FieldType { Name = fieldArgument.Name };
+                                    var parentType = context.TypeInfo.GetParentType() ?? throw new InvalidOperationException("Parent type must not be null.");
+                                    context.ReportError(new KnownArgumentNamesError(context, node, fieldClone, parentType));
+                                }
+                            }
+
+                            break;
+                        }
+
+                    case Directive:
+                        {
+                            var directive = context.TypeInfo.GetDirective();
+                            if (directive != null)
+                            {
+                                var directiveArgument = directive.Arguments?.Find(node.Name);
+                                if (directiveArgument == null)
+                                {
+                                    var directiveClone = new DirectiveGraphType(directive.Name, directive.Locations);
+                                    context.ReportError(new KnownArgumentNamesError(context, node, directiveClone));
+                                }
+                            }
+
+                            break;
+                        }
+                }
+            }
+        }
+    }
+}

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Infrastructure/Validation/CustomKnownTypeNames.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Infrastructure/Validation/CustomKnownTypeNames.cs
@@ -1,0 +1,26 @@
+using System.Threading.Tasks;
+using GraphQL.Language.AST;
+using GraphQL.Validation;
+using GraphQL.Validation.Errors;
+
+namespace VirtoCommerce.ExperienceApiModule.Core.Infrastructure.Validation
+{
+    public class CustomKnownTypeNames : IValidationRule
+    {
+        public virtual async Task<INodeVisitor> ValidateAsync(ValidationContext context)
+        {
+            var visitor = new NodeVisitors(new MatchingNodeVisitor<NamedType>((node, context) => Validate(node, context)));
+
+            return await Task.FromResult(visitor);
+        }
+
+        protected virtual void Validate(NamedType node, ValidationContext context)
+        {
+            var type = context.Schema.AllTypes[node.Name];
+            if (type == null)
+            {
+                context.ReportError(new KnownTypeNamesError(context, node, suggestedTypes: null));
+            }
+        }
+    }
+}

--- a/src/VirtoCommerce.ExperienceApiModule.Web/Module.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Web/Module.cs
@@ -69,17 +69,24 @@ namespace VirtoCommerce.ExperienceApiModule.Web
 
             if (!IsSchemaIntrospectionEnabled)
             {
-                var rulesTypesToReplace = new List<Type> { typeof(KnownTypeNames), typeof(FieldsOnCorrectType), typeof(KnownArgumentNames) };
+                var rulesMap = new Dictionary<Type, Type>()
+                {
+                    { typeof(KnownTypeNames), typeof(CustomKnownTypeNames) },
+                    { typeof(FieldsOnCorrectType), typeof(CustomFieldsOnCorrectType) },
+                    { typeof(KnownArgumentNames), typeof(CustomKnownArgumentNames) }
+                };
 
                 var coreRules = DocumentValidator.CoreRules as List<IValidationRule>;
-                foreach (var rule in DocumentValidator.CoreRules.Where(x => rulesTypesToReplace.Contains(x.GetType())).ToArray())
-                {
-                    coreRules.Remove(rule);
-                }
 
-                graphQlBuilder.AddCustomValidationRule<CustomKnownArgumentNames>()
-                    .AddCustomValidationRule<CustomKnownTypeNames>()
-                    .AddCustomValidationRule<CustomFieldsOnCorrectType>();
+                foreach (var rule in rulesMap)
+                {
+                    var ruleToReplace = coreRules?.FirstOrDefault(x => x.GetType() == rule.Key);
+                    if (ruleToReplace != null)
+                    {
+                        coreRules.Remove(ruleToReplace);
+                        graphQlBuilder.AddCustomValidationRule(rule.Value);
+                    }
+                }
             }
 
             //Register custom GraphQL dependencies


### PR DESCRIPTION
## Description
1. PT-14888. Disabled application/x-www-form-urlencoded ContentType:
if you send raw query where body is formatted as url encoded, for example:
```
query=query%7Bcountries%7Bid%7D%7D
```
and ContentType header is `application/x-www-form-urlencoded` the result will be:
![Screenshot_26](https://github.com/VirtoCommerce/vc-module-experience-api/assets/20122385/94bfacc7-3e34-49c8-bc26-9c092cbc92be)

2. PT-14894. Disabled suggestions in errors when the app setting `VirtoCommerce:GraphQLPlayground:Enable` is `false`:
if you send incorrect query, for example:
```
query{countrie{id}}
```
the result will be:
![Screenshot_25](https://github.com/VirtoCommerce/vc-module-experience-api/assets/20122385/894ea0aa-7ea4-417e-ac9e-df2307bd936c)

For comparison when  `VirtoCommerce:GraphQLPlayground:Enable` is `true`:
![Screenshot_27](https://github.com/VirtoCommerce/vc-module-experience-api/assets/20122385/b5ca1477-1bfd-4ecd-a131-c7f64d38dd90)

## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/PT-14888
https://virtocommerce.atlassian.net/browse/PT-14894
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.446.0-pr-503-64ae.zip
