### PR TITLE
PT-14841: orders filter can be corrupted

### DIFF
--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/CustomerOrderSearchCriteriaBuilder.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/CustomerOrderSearchCriteriaBuilder.cs
@@ -44,13 +44,23 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder
 
         public CustomerOrderSearchCriteriaBuilder WithCustomerId(string customerId)
         {
-            _searchCriteria.Keyword += !string.IsNullOrEmpty(customerId) ? $" customerId:\"{customerId}\"" : string.Empty;
+            if (!string.IsNullOrEmpty(customerId))
+            {
+                // customerId should be added before custom Keyword to prevent overriding
+                _searchCriteria.Keyword = $"customerId:\"{customerId}\" {_searchCriteria.Keyword}";
+            }
+
             return this;
         }
 
         public CustomerOrderSearchCriteriaBuilder WithOrganizationId(string organizationId)
         {
-            _searchCriteria.Keyword += !string.IsNullOrEmpty(organizationId) ? $" organizationId:\"{organizationId}\"" : string.Empty;
+            if (!string.IsNullOrEmpty(organizationId))
+            {
+                // organizationId should be added before custom Keyword to prevent overriding
+                _searchCriteria.Keyword = $"organizationId:\"{organizationId}\" {_searchCriteria.Keyword}";
+            }
+
             return this;
         }
 


### PR DESCRIPTION
## Description
fix: The range filter in order search can be corrupted if using the date time format. Use encoding. Ex: "createddate:[\"2023-12-01T08:00:00.000Z\" TO \"2023-12-20T08:00:00.000Z\"] otherwise only the date will be taken.

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/PT-14841
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.448.0-pr-507-856a.zip
