### PR TITLE
VCST-329: Error when user try to search order

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ExperienceApiModule.Web/module.manifest
@@ -12,7 +12,7 @@
     <dependency id="VirtoCommerce.Customer" version="3.800.0" />
     <dependency id="VirtoCommerce.Inventory" version="3.800.0" />
     <dependency id="VirtoCommerce.Marketing" version="3.800.0" />
-    <dependency id="VirtoCommerce.Orders" version="3.800.0" />
+    <dependency id="VirtoCommerce.Orders" version="3.802.0" />
     <dependency id="VirtoCommerce.Payment" version="3.800.0" />
     <dependency id="VirtoCommerce.Pricing" version="3.800.0" />
     <dependency id="VirtoCommerce.Search" version="3.800.0" />

--- a/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/CustomerOrderSearchCriteriaBuilder.cs
+++ b/src/XPurchase/VirtoCommerce.ExperienceApiModule.XOrder/CustomerOrderSearchCriteriaBuilder.cs
@@ -9,7 +9,7 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder
     public class CustomerOrderSearchCriteriaBuilder
     {
         private readonly ISearchPhraseParser _phraseParser;
-        private readonly CustomerOrderIndexedSearchCriteria _searchCriteria;
+        private readonly CustomerOrderSearchCriteria _searchCriteria;
 
         public CustomerOrderSearchCriteriaBuilder(ISearchPhraseParser phraseParser) : this()
         {
@@ -18,12 +18,12 @@ namespace VirtoCommerce.ExperienceApiModule.XOrder
 
         public CustomerOrderSearchCriteriaBuilder()
         {
-            _searchCriteria = AbstractTypeFactory<CustomerOrderIndexedSearchCriteria>.TryCreateInstance();
+            _searchCriteria = AbstractTypeFactory<CustomerOrderSearchCriteria>.TryCreateInstance();
         }
 
-        public virtual CustomerOrderIndexedSearchCriteria Build()
+        public virtual CustomerOrderSearchCriteria Build()
         {
-            return _searchCriteria.Clone() as CustomerOrderIndexedSearchCriteria;
+            return _searchCriteria.Clone() as CustomerOrderSearchCriteria;
         }
 
         public CustomerOrderSearchCriteriaBuilder ParseFilters(string filterPhrase)

--- a/src/XPurchase/VirtoCommerce.XPurchase/VirtoCommerce.XPurchase.csproj
+++ b/src/XPurchase/VirtoCommerce.XPurchase/VirtoCommerce.XPurchase.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="GraphQL.DataLoader" Version="4.6.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="PipelineNet" Version="0.9.0" />
-    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.800.0" />
+    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.802.0" />
     <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.800.0" />
     <PackageReference Include="VirtoCommerce.ShippingModule.Core" Version="3.800.0" />
   </ItemGroup>


### PR DESCRIPTION
## Description
fix: Error when user try to search order by breaking change in Order v3.802. Bump version of order module to v3.802 and refactor CustomerOrderSearchCriteriaBuilder class.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-329
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.801.0-pr-518-fd35.zip
