### PR TITLE
VCST-560: make EvalSearchRequestUserGroupsMiddleware virtual

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Middlewares/EvalSearchRequestUserGroupsMiddleware.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Middlewares/EvalSearchRequestUserGroupsMiddleware.cs
@@ -25,7 +25,7 @@ namespace VirtoCommerce.XDigitalCatalog.Middlewares
             _moduleCatalog = moduleCatalog;
         }
 
-        public async Task Run(IndexSearchRequestBuilder parameter, Func<IndexSearchRequestBuilder, Task> next)
+        public virtual async Task Run(IndexSearchRequestBuilder parameter, Func<IndexSearchRequestBuilder, Task> next)
         {
             /// Please note that this solution is temporary. In the upcoming release, we are actively working on resolving this issue by introducing optional dependencies.
             /// With optional dependencies, the XAPI will seamlessly integrate with the Catalog Personalization Module if it is installed, and gracefully handle scenarios where the module is not present.


### PR DESCRIPTION
## Description
Usage:
```cs
  serviceCollection.AddPipeline<IndexSearchRequestBuilder>(builder =>
  {
      builder.ReplaceMiddleware(typeof(EvalSearchRequestUserGroupsMiddleware), typeof(EvalSearchRequestUserGroupsMiddlewareExtended));
  });
```

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-560
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.808.0-pr-528-7f56.zip
