### PR TITLE
VCST-562: Add PasswordRequirements to store query

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.Core/Queries/GetStoreQueryHandler.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Queries/GetStoreQueryHandler.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
 using VirtoCommerce.CoreModule.Core.Common;
 using VirtoCommerce.ExperienceApiModule.Core.Infrastructure;
 using VirtoCommerce.Platform.Core.Common;
@@ -16,11 +18,13 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Queries
     {
         private readonly IStoreService _storeService;
         private readonly IStoreCurrencyResolver _storeCurrencyResolver;
+        private readonly IdentityOptions _identityOptions;
 
-        public GetStoreQueryHandler(IStoreService storeService, IStoreCurrencyResolver storeCurrencyResolver)
+        public GetStoreQueryHandler(IStoreService storeService, IStoreCurrencyResolver storeCurrencyResolver, IOptions<IdentityOptions> identityOptions)
         {
             _storeService = storeService;
             _storeCurrencyResolver = storeCurrencyResolver;
+            _identityOptions = identityOptions.Value;
         }
 
         public async Task<StoreResponse> Handle(GetStoreQuery request, CancellationToken cancellationToken)
@@ -67,6 +71,8 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Queries
 
                     QuotesEnabled = store.Settings.GetValue<bool>(new SettingDescriptor { Name = "Quotes.EnableQuotes" }),
                     SubscriptionEnabled = store.Settings.GetValue<bool>(new SettingDescriptor { Name = "Subscription.EnableSubscriptions" }),
+
+                    PasswordRequirements = _identityOptions.Password,
                 };
             }
 

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Queries/StoreSettings.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Queries/StoreSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace VirtoCommerce.ExperienceApiModule.Core.Queries
+using Microsoft.AspNetCore.Identity;
+
+namespace VirtoCommerce.ExperienceApiModule.Core.Queries
 {
     public class StoreSettings
     {
@@ -19,5 +21,7 @@
         public bool CreateAnonymousOrderEnabled { get; set; }
 
         public string SeoLinkType { get; set; }
+
+        public PasswordOptions PasswordRequirements { get; set; }
     }
 }

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/PasswordOptionsType.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/PasswordOptionsType.cs
@@ -1,0 +1,17 @@
+using GraphQL.Types;
+using Microsoft.AspNetCore.Identity;
+
+namespace VirtoCommerce.ExperienceApiModule.Core.Schemas;
+
+public class PasswordOptionsType : ObjectGraphType<PasswordOptions>
+{
+    public PasswordOptionsType()
+    {
+        Field(x => x.RequiredLength, nullable: false).Description("The minimum length a password must be.");
+        Field(x => x.RequiredUniqueChars, nullable: false).Description("The minimum number of unique chars a password must comprised of.");
+        Field(x => x.RequireNonAlphanumeric, nullable: false).Description("Require a non letter or digit character.");
+        Field(x => x.RequireLowercase, nullable: false).Description("Require a lower case letter ('a' - 'z').");
+        Field(x => x.RequireUppercase, nullable: false).Description("Require an upper case letter ('A' - 'Z').");
+        Field(x => x.RequireDigit, nullable: false).Description("Require a digit ('0' - '9').");
+    }
+}

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/StoreSettingsType.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/StoreSettingsType.cs
@@ -1,4 +1,4 @@
-﻿using VirtoCommerce.ExperienceApiModule.Core.Queries;
+using VirtoCommerce.ExperienceApiModule.Core.Queries;
 
 namespace VirtoCommerce.ExperienceApiModule.Core.Schemas
 {
@@ -15,6 +15,7 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Schemas
             Field(x => x.EmailVerificationRequired).Description("Email address verification required");
             Field(x => x.CreateAnonymousOrderEnabled).Description("Allow anonymous users to create orders (XAPI)");
             Field(x => x.SeoLinkType).Description("SEO links");
+            Field<PasswordOptionsType>("passwordRequirements", "Password requirements");
         }
     }
 }


### PR DESCRIPTION
## Description
feat: Added PasswordRequirements (PasswordOptions) to StoreSettings in the Experience API module. This allows to query password requirements on a per-store basis. The PasswordOptions includes settings for minimum length, required unique characters, requirement for non-alphanumeric characters, lowercase and uppercase letters, and digits.

### Query
```graphql
query{
  store(storeId: "B2B-store", cultureName: "en-US") {
    storeId
    settings {
      passwordRequirements {
        requireLowercase
        requireUppercase
        requireDigit
        requiredLength
        requiredUniqueChars
        requireNonAlphanumeric
      }
    }
  }
}
```

### Response
```graphql
{
  "data": {
    "store": {
      "storeId": "B2B-store",
      "settings": {
        "passwordRequirements": {
          "requireLowercase": true,
          "requireUppercase": true,
          "requireDigit": false,
          "requiredLength": 8,
          "requiredUniqueChars": 1,
          "requireNonAlphanumeric": false
        }
      }
    }
  }
}
```

## References
### QA-test:
### Jira-link:
### Artifact URL:
