### PR TITLE
VCST-596: Extend store settings with installed module id and public settings

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.Core/Models/ProductPrice.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Models/ProductPrice.cs
@@ -92,13 +92,13 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Models
         /// <returns></returns>
         public TierPrice GetTierPrice(int quantity)
         {
-            var retVal = TierPrices.OrderBy(x => x.Quantity).LastOrDefault(x => x.Quantity <= quantity);
-            if (retVal == null)
+            var result = TierPrices.OrderBy(x => x.Quantity).LastOrDefault(x => x.Quantity <= quantity);
+            if (result == null)
             {
-                retVal = new TierPrice(ListPrice, SalePrice, 1);
+                result = new TierPrice(ListPrice, SalePrice, 1);
             }
 
-            return retVal;
+            return result;
         }
 
         #region ITaxable Members

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Queries/GetStoreQueryHandler.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Queries/GetStoreQueryHandler.cs
@@ -106,16 +106,17 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Queries
             return retVal.ToArray();
         }
 
-        protected virtual string ToSettingValue(ObjectSettingEntry s)
+        protected virtual object ToSettingValue(ObjectSettingEntry s)
         {
-            var retVal = s.Value?.ToString() ?? s.DefaultValue?.ToString();
+            var retVal = s.Value ?? s.DefaultValue;
 
-            if (string.IsNullOrEmpty(retVal))
+            if (retVal == null)
             {
                 switch (s.ValueType)
                 {
                     case SettingValueType.Boolean:
-                        return false.ToString();
+                        retVal = false;
+                        break;
                 }
             }
 

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Queries/GetStoreQueryHandler.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Queries/GetStoreQueryHandler.cs
@@ -83,7 +83,7 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Queries
 
         protected virtual ModuleSettings[] ToModulesSettings(ICollection<ObjectSettingEntry> settings)
         {
-            var retVal = new List<ModuleSettings>();
+            var result = new List<ModuleSettings>();
 
             foreach (var settingByModule in settings.Where(s => s.IsPublic).GroupBy(s => s.ModuleId))
             {
@@ -99,28 +99,28 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Queries
 
                 if (moduleSettings.Settings.Length > 0)
                 {
-                    retVal.Add(moduleSettings);
+                    result.Add(moduleSettings);
                 }
             }
 
-            return retVal.ToArray();
+            return result.ToArray();
         }
 
         protected virtual object ToSettingValue(ObjectSettingEntry s)
         {
-            var retVal = s.Value ?? s.DefaultValue;
+            var result = s.Value ?? s.DefaultValue;
 
-            if (retVal == null)
+            if (result == null)
             {
                 switch (s.ValueType)
                 {
                     case SettingValueType.Boolean:
-                        retVal = false;
+                        result = false;
                         break;
                 }
             }
 
-            return retVal;
+            return result;
         }
     }
 }

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Queries/GetStoreQueryHandler.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Queries/GetStoreQueryHandler.cs
@@ -85,7 +85,7 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Queries
         {
             var retVal = new List<ModuleSettings>();
 
-            foreach (var settingByModule in settings.GroupBy(s => s.ModuleId))
+            foreach (var settingByModule in settings.Where(s => s.IsPublic).GroupBy(s => s.ModuleId))
             {
                 var moduleSettings = new ModuleSettings
                 {

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Queries/ModuleSetting.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Queries/ModuleSetting.cs
@@ -1,0 +1,7 @@
+namespace VirtoCommerce.ExperienceApiModule.Core.Queries;
+
+public class ModuleSetting
+{
+    public string Name { get; set; }
+    public object Value { get; set; }
+}

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Queries/ModuleSettings.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Queries/ModuleSettings.cs
@@ -1,0 +1,14 @@
+namespace VirtoCommerce.ExperienceApiModule.Core.Queries;
+
+public class ModuleSetting
+{
+    public string Name { get; set; }
+    public string Value { get; set; }
+}
+
+public class ModuleSettings
+{
+    public string ModuleId { get; set; }
+
+    public ModuleSetting[] Settings { get; set; }
+}

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Queries/ModuleSettings.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Queries/ModuleSettings.cs
@@ -3,7 +3,7 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Queries;
 public class ModuleSetting
 {
     public string Name { get; set; }
-    public string Value { get; set; }
+    public object Value { get; set; }
 }
 
 public class ModuleSettings

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Queries/ModuleSettings.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Queries/ModuleSettings.cs
@@ -1,11 +1,5 @@
 namespace VirtoCommerce.ExperienceApiModule.Core.Queries;
 
-public class ModuleSetting
-{
-    public string Name { get; set; }
-    public object Value { get; set; }
-}
-
 public class ModuleSettings
 {
     public string ModuleId { get; set; }

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Queries/StoreSettings.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Queries/StoreSettings.cs
@@ -23,5 +23,7 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Queries
         public string SeoLinkType { get; set; }
 
         public PasswordOptions PasswordRequirements { get; set; }
+
+        public ModuleSettings[] Modules { get; set; }
     }
 }

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/ModuleSettingType.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/ModuleSettingType.cs
@@ -1,5 +1,6 @@
 using GraphQL.Types;
 using VirtoCommerce.ExperienceApiModule.Core.Queries;
+using VirtoCommerce.ExperienceApiModule.Core.Schemas.ScalarTypes;
 
 namespace VirtoCommerce.ExperienceApiModule.Core.Schemas;
 
@@ -8,6 +9,6 @@ public class ModuleSettingType : ObjectGraphType<ModuleSetting>
     public ModuleSettingType()
     {
         Field(x => x.Name, nullable: false);
-        Field(x => x.Value, nullable: true);
+        Field<ModuleSettingValueGraphType>("value", resolve: x => x.Source.Value);
     }
 }

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/ModuleSettingType.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/ModuleSettingType.cs
@@ -1,0 +1,13 @@
+using GraphQL.Types;
+using VirtoCommerce.ExperienceApiModule.Core.Queries;
+
+namespace VirtoCommerce.ExperienceApiModule.Core.Schemas;
+
+public class ModuleSettingType : ObjectGraphType<ModuleSetting>
+{
+    public ModuleSettingType()
+    {
+        Field(x => x.Name, nullable: false);
+        Field(x => x.Value, nullable: true);
+    }
+}

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/ModuleSettingsType.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/ModuleSettingsType.cs
@@ -1,0 +1,13 @@
+using GraphQL.Types;
+using VirtoCommerce.ExperienceApiModule.Core.Queries;
+
+namespace VirtoCommerce.ExperienceApiModule.Core.Schemas;
+
+public class ModuleSettingsType : ObjectGraphType<ModuleSettings>
+{
+    public ModuleSettingsType()
+    {
+        Field(x => x.ModuleId, nullable: false);
+        Field<ListGraphType<ModuleSettingType>>("settings");
+    }
+}

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/ModuleSettingsType.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/ModuleSettingsType.cs
@@ -8,6 +8,6 @@ public class ModuleSettingsType : ObjectGraphType<ModuleSettings>
     public ModuleSettingsType()
     {
         Field(x => x.ModuleId, nullable: false);
-        Field<ListGraphType<ModuleSettingType>>("settings");
+        Field<NonNullGraphType<ListGraphType<NonNullGraphType<ModuleSettingType>>>>("settings");
     }
 }

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/ScalarTypes/ModuleSettingValueGraphType.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/ScalarTypes/ModuleSettingValueGraphType.cs
@@ -1,0 +1,6 @@
+namespace VirtoCommerce.ExperienceApiModule.Core.Schemas.ScalarTypes
+{
+    public sealed class ModuleSettingValueGraphType : AnyValueGraphType
+    {
+    }
+}

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/StoreSettingsType.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/StoreSettingsType.cs
@@ -1,21 +1,23 @@
+using GraphQL.Types;
+using MediatR;
 using VirtoCommerce.ExperienceApiModule.Core.Queries;
 
-namespace VirtoCommerce.ExperienceApiModule.Core.Schemas
+namespace VirtoCommerce.ExperienceApiModule.Core.Schemas;
+
+public class StoreSettingsType : ExtendableGraphType<StoreSettings>
 {
-    public class StoreSettingsType : ExtendableGraphType<StoreSettings>
+    public StoreSettingsType(IMediator mediator)
     {
-        public StoreSettingsType()
-        {
-            Field(x => x.QuotesEnabled).Description("Store ID");
-            Field(x => x.SubscriptionEnabled).Description("Store ID");
-            Field(x => x.TaxCalculationEnabled).Description("Tax calculation enabled");
-            Field(x => x.AnonymousUsersAllowed).Description("Allow anonymous users to visit the store ");
-            Field(x => x.IsSpa).Description("SPA");
-            Field(x => x.EmailVerificationEnabled).Description("Email address verification enabled");
-            Field(x => x.EmailVerificationRequired).Description("Email address verification required");
-            Field(x => x.CreateAnonymousOrderEnabled).Description("Allow anonymous users to create orders (XAPI)");
-            Field(x => x.SeoLinkType).Description("SEO links");
-            Field<PasswordOptionsType>("passwordRequirements", "Password requirements");
-        }
+        Field(x => x.QuotesEnabled).Description("Store ID");
+        Field(x => x.SubscriptionEnabled).Description("Store ID");
+        Field(x => x.TaxCalculationEnabled).Description("Tax calculation enabled");
+        Field(x => x.AnonymousUsersAllowed).Description("Allow anonymous users to visit the store ");
+        Field(x => x.IsSpa).Description("SPA");
+        Field(x => x.EmailVerificationEnabled).Description("Email address verification enabled");
+        Field(x => x.EmailVerificationRequired).Description("Email address verification required");
+        Field(x => x.CreateAnonymousOrderEnabled).Description("Allow anonymous users to create orders (XAPI)");
+        Field(x => x.SeoLinkType).Description("SEO links");
+        Field<PasswordOptionsType>("passwordRequirements", "Password requirements");
+        Field<ListGraphType<ModuleSettingsType>>("modules");
     }
 }

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/StoreSettingsType.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/StoreSettingsType.cs
@@ -1,12 +1,11 @@
 using GraphQL.Types;
-using MediatR;
 using VirtoCommerce.ExperienceApiModule.Core.Queries;
 
 namespace VirtoCommerce.ExperienceApiModule.Core.Schemas;
 
 public class StoreSettingsType : ExtendableGraphType<StoreSettings>
 {
-    public StoreSettingsType(IMediator mediator)
+    public StoreSettingsType()
     {
         Field(x => x.QuotesEnabled).Description("Store ID");
         Field(x => x.SubscriptionEnabled).Description("Store ID");
@@ -18,6 +17,6 @@ public class StoreSettingsType : ExtendableGraphType<StoreSettings>
         Field(x => x.CreateAnonymousOrderEnabled).Description("Allow anonymous users to create orders (XAPI)");
         Field(x => x.SeoLinkType).Description("SEO links");
         Field<PasswordOptionsType>("passwordRequirements", "Password requirements");
-        Field<ListGraphType<ModuleSettingsType>>("modules");
+        Field<NonNullGraphType<ListGraphType<NonNullGraphType<ModuleSettingsType>>>>("modules");
     }
 }

--- a/src/VirtoCommerce.ExperienceApiModule.Core/VirtoCommerce.ExperienceApiModule.Core.csproj
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/VirtoCommerce.ExperienceApiModule.Core.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="RedLock.net" Version="2.3.2" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.800.0" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.800.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.809.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.813.0-alpha.12873-vcst-596-module-store-settings" />
     <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.800.0" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.800.0" />
     <PackageReference Include="VirtoCommerce.TaxModule.Core" Version="3.800.0" />

--- a/src/VirtoCommerce.ExperienceApiModule.Core/VirtoCommerce.ExperienceApiModule.Core.csproj
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/VirtoCommerce.ExperienceApiModule.Core.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="RedLock.net" Version="2.3.2" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.800.0" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.800.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.813.0-alpha.12873-vcst-596-module-store-settings" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.813.0" />
     <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.800.0" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.800.0" />
     <PackageReference Include="VirtoCommerce.TaxModule.Core" Version="3.800.0" />

--- a/src/VirtoCommerce.ExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ExperienceApiModule.Web/module.manifest
@@ -3,7 +3,7 @@
   <id>VirtoCommerce.ExperienceApi</id>
   <version>3.811.0</version>
   <version-tag />
-  <platformVersion>3.809.0</platformVersion>
+  <platformVersion>3.813.0-alpha.12873-vcst-596-module-store-settings</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Cart" version="3.801.0" />
     <dependency id="VirtoCommerce.Catalog" version="3.800.0" />

--- a/src/VirtoCommerce.ExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ExperienceApiModule.Web/module.manifest
@@ -3,7 +3,7 @@
   <id>VirtoCommerce.ExperienceApi</id>
   <version>3.811.0</version>
   <version-tag />
-  <platformVersion>3.813.0-alpha.12873-vcst-596-module-store-settings</platformVersion>
+  <platformVersion>3.813.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Cart" version="3.801.0" />
     <dependency id="VirtoCommerce.Catalog" version="3.800.0" />


### PR DESCRIPTION
## Description
feat:  Expanded store settings query to include installed modules and public store settings for each module. This enhancement enables frontend applications to efficiently access module settings.
Set the store platform setting to true to ensure accessibility and visibility of settings across the store query in XAPI. Example of the modules with public settings: Google Analytics, Hotjar, etc.

```graphql
query{
  store(storeId: "B2B-store", cultureName: "en-US") {
    storeId
    settings {
      modules { moduleId settings { name value } }
    }
  }
}
```

![image](https://github.com/VirtoCommerce/vc-module-experience-api/assets/7639413/6d9766b1-92ea-464f-8c11-3df5dbd13cd2)

## References
### QA-test:
### Jira-link:



https://virtocommerce.atlassian.net/browse/VCST-596
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.812.0-pr-535-6563.zip
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.812.0-pr-535-8460.zip

