### PR TITLE
VCST-566: Resolve seoslug with empty store.

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.Core/Queries/SlugInfoQueryHandler.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Queries/SlugInfoQueryHandler.cs
@@ -46,12 +46,20 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Queries
             return result;
         }
 
-        private async Task<SeoInfo> GetBestMatchingSeoInfo(Store store, string slug, string currentCulture)
+        protected virtual async Task<SeoInfo> GetBestMatchingSeoInfo(Store store, string slug, string currentCulture)
         {
-            var seoInfos = (await _seoBySlugResolver.FindSeoBySlugAsync(slug))
-                .Where(x => x.StoreId == store.Id)
-                .ToArray();
-            var bestMatchSeoInfo = seoInfos.GetBestMatchingSeoInfo(store.Id, currentCulture, slug);
+            var itemsToMatch = await _seoBySlugResolver.FindSeoBySlugAsync(slug);
+
+            var seoInfosForStore = itemsToMatch.Where(x => x.StoreId == store.Id).ToArray();
+
+            var bestMatchSeoInfo = seoInfosForStore.GetBestMatchingSeoInfo(store.Id, currentCulture, slug);
+
+            if (bestMatchSeoInfo == null)
+            {
+                var seoInfosWithoutStore = itemsToMatch.Where(x => string.IsNullOrEmpty(x.StoreId)).ToArray();
+                bestMatchSeoInfo = seoInfosWithoutStore.GetBestMatchingSeoInfo(store.Id, currentCulture, slug);
+            }
+
             return bestMatchSeoInfo;
         }
     }

--- a/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS/PageItem.cs
+++ b/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS/PageItem.cs
@@ -2,8 +2,10 @@ namespace VirtoCommerce.ExperienceApiModule.XCMS
 {
     public class PageItem
     {
+        public string Id { get; set; }
         public string Name { get; set; }
         public string Permalink { get; set; }
         public string RelativeUrl { get; set; }
+        public string Content { get; set; }
     }
 }

--- a/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS/Queries/GetSinglePageQuery.cs
+++ b/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS/Queries/GetSinglePageQuery.cs
@@ -1,0 +1,10 @@
+using VirtoCommerce.ExperienceApiModule.Core.Infrastructure;
+
+namespace VirtoCommerce.ExperienceApiModule.XCMS.Queries;
+
+public class GetSinglePageQuery : IQuery<PageItem>
+{
+    public string StoreId { get; set; }
+    public string CultureName { get; set; }
+    public string Id { get; set; }
+}

--- a/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS/Queries/GetSinglePageQueryHandler.cs
+++ b/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS/Queries/GetSinglePageQueryHandler.cs
@@ -21,8 +21,8 @@ public class GetSinglePageQueryHandler : IQueryHandler<GetSinglePageQuery, PageI
         var criteria = new ContentSearchCriteria
         {
             StoreId = request.StoreId,
-            Keyword = $"_id:{request.Id}",
             LanguageCode = request.CultureName,
+            ObjectIds = [request.Id],
             Take = 1,
             Skip = 0,
         };

--- a/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS/Queries/GetSinglePageQueryHandler.cs
+++ b/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS/Queries/GetSinglePageQueryHandler.cs
@@ -21,7 +21,6 @@ public class GetSinglePageQueryHandler : IQueryHandler<GetSinglePageQuery, PageI
         var criteria = new ContentSearchCriteria
         {
             StoreId = request.StoreId,
-            LanguageCode = request.CultureName,
             ObjectIds = [request.Id],
             Take = 1,
             Skip = 0,

--- a/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS/Queries/GetSinglePageQueryHandler.cs
+++ b/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS/Queries/GetSinglePageQueryHandler.cs
@@ -7,33 +7,35 @@ using VirtoCommerce.ExperienceApiModule.Core.Infrastructure;
 
 namespace VirtoCommerce.ExperienceApiModule.XCMS.Queries;
 
-public class GetPageQueryHandler : IQueryHandler<GetPageQuery, GetPageResponse>
+public class GetSinglePageQueryHandler : IQueryHandler<GetSinglePageQuery, PageItem>
 {
     private readonly IFullTextContentSearchService _searchContentService;
 
-    public GetPageQueryHandler(IFullTextContentSearchService searchContentService)
+    public GetSinglePageQueryHandler(IFullTextContentSearchService searchContentService)
     {
         _searchContentService = searchContentService;
     }
 
-    public async Task<GetPageResponse> Handle(GetPageQuery request, CancellationToken cancellationToken)
+    public async Task<PageItem> Handle(GetSinglePageQuery request, CancellationToken cancellationToken)
     {
         var criteria = new ContentSearchCriteria
         {
             StoreId = request.StoreId,
-            Keyword = request.Keyword,
+            Keyword = $"_id:{request.Id}",
             LanguageCode = request.CultureName,
-            Take = request.Take,
-            Skip = request.Skip,
+            Take = 1,
+            Skip = 0,
         };
         var result = await _searchContentService.SearchContentAsync(criteria);
-        var pages = result.Results.Select(x => new PageItem
+
+        var page = result.Results.Select(x => new PageItem
         {
             Id = x.Id,
             Name = string.IsNullOrEmpty(x.DisplayName) ? x.Name : x.DisplayName,
             RelativeUrl = x.RelativeUrl,
             Permalink = x.Permalink
-        });
-        return new GetPageResponse { Pages = pages, TotalCount = result.TotalCount };
+        }).First();
+
+        return page;
     }
 }

--- a/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS/Schemas/PageType.cs
+++ b/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS/Schemas/PageType.cs
@@ -1,14 +1,42 @@
+using System.IO;
+using System.Threading.Tasks;
+using GraphQL;
 using GraphQL.Types;
+using VirtoCommerce.ContentModule.Core.Services;
+using VirtoCommerce.ExperienceApiModule.Core.Extensions;
 
 namespace VirtoCommerce.ExperienceApiModule.XCMS.Schemas
 {
     public class PageType : ObjectGraphType<PageItem>
     {
-        public PageType()
+        private readonly IContentService _contentService;
+
+        public PageType(IContentService contentService)
         {
+            _contentService = contentService;
+
+            Field(x => x.Id, nullable: false);
             Field(x => x.Name, nullable: true).Description("Page title");
             Field(x => x.RelativeUrl, nullable: false).Description("Page file relative url");
             Field(x => x.Permalink, nullable: true).Description("Page permalink");
+            Field(x => x.Content, nullable: false).ResolveAsync(LoadContent);
+        }
+
+        protected virtual async Task<string> LoadContent(IResolveFieldContext<PageItem> context)
+        {
+            try
+            {
+                var storeId = context.GetArgumentOrValue<string>("storeId");
+
+                using var stream = await _contentService.GetItemStreamAsync("pages", storeId,
+                    context.Source.RelativeUrl);
+                using var streamReader = new StreamReader(stream);
+                return await streamReader.ReadToEndAsync();
+            }
+            catch (System.Exception)
+            {
+                throw new FileNotFoundException(context.Source.RelativeUrl);
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
fix: Resolves seo by slug with empty store.
feat: Adds page query that allows request page content by id.
feat: Extends pages query with content property.

```graphql
query{
  pages(storeId: "B2B-store", keyword: "Test" ) {
    totalCount
    items{ permalink relativeUrl name id content }
  }
}
```

```graphql
query{
  page(storeId: "B2B-store", id: "QjJCLXN0b3JlOjpwYWdlczo6L2hvbWVwYWdlLnBhZ2U-" ) {
    id name content
  }
}
```

## References
### QA-test:
### Jira-link:



https://virtocommerce.atlassian.net/browse/VCST-566
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.811.0-pr-536-ddfe.zip
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.811.0-pr-536-4c01.zip
