### PR TITLE
VCST-689: Add ContentType filter for pages

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ExperienceApiModule.Web/module.manifest
@@ -7,7 +7,7 @@
   <dependencies>
     <dependency id="VirtoCommerce.Cart" version="3.801.0" />
     <dependency id="VirtoCommerce.Catalog" version="3.800.0" />
-    <dependency id="VirtoCommerce.Content" version="3.800.0" />
+    <dependency id="VirtoCommerce.Content" version="3.802.0-pr-170-852d" />
     <dependency id="VirtoCommerce.Core" version="3.800.0" />
     <dependency id="VirtoCommerce.Customer" version="3.800.0" />
     <dependency id="VirtoCommerce.Inventory" version="3.800.0" />

--- a/src/VirtoCommerce.ExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ExperienceApiModule.Web/module.manifest
@@ -7,7 +7,7 @@
   <dependencies>
     <dependency id="VirtoCommerce.Cart" version="3.801.0" />
     <dependency id="VirtoCommerce.Catalog" version="3.800.0" />
-    <dependency id="VirtoCommerce.Content" version="3.802.0-pr-170-852d" />
+    <dependency id="VirtoCommerce.Content" version="3.802.0" />
     <dependency id="VirtoCommerce.Core" version="3.800.0" />
     <dependency id="VirtoCommerce.Customer" version="3.800.0" />
     <dependency id="VirtoCommerce.Inventory" version="3.800.0" />

--- a/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS/Queries/GetPageQueryHandler.cs
+++ b/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS/Queries/GetPageQueryHandler.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using VirtoCommerce.ContentModule.Core.Model;
 using VirtoCommerce.ContentModule.Core.Search;
 using VirtoCommerce.ExperienceApiModule.Core.Infrastructure;
+using static VirtoCommerce.ContentModule.Core.ContentConstants;
 
 namespace VirtoCommerce.ExperienceApiModule.XCMS.Queries;
 
@@ -21,8 +22,9 @@ public class GetPageQueryHandler : IQueryHandler<GetPageQuery, GetPageResponse>
         var criteria = new ContentSearchCriteria
         {
             StoreId = request.StoreId,
-            Keyword = request.Keyword,
+            ContentType = ContentTypes.Pages,
             LanguageCode = request.CultureName,
+            Keyword = request.Keyword,
             Take = request.Take,
             Skip = request.Skip,
         };

--- a/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS/Queries/GetSinglePageQueryHandler.cs
+++ b/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS/Queries/GetSinglePageQueryHandler.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using VirtoCommerce.ContentModule.Core.Model;
 using VirtoCommerce.ContentModule.Core.Search;
 using VirtoCommerce.ExperienceApiModule.Core.Infrastructure;
+using static VirtoCommerce.ContentModule.Core.ContentConstants;
 
 namespace VirtoCommerce.ExperienceApiModule.XCMS.Queries;
 
@@ -21,6 +22,7 @@ public class GetSinglePageQueryHandler : IQueryHandler<GetSinglePageQuery, PageI
         var criteria = new ContentSearchCriteria
         {
             StoreId = request.StoreId,
+            ContentType = ContentTypes.Pages,
             ObjectIds = [request.Id],
             Take = 1,
             Skip = 0,

--- a/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS/VirtoCommerce.ExperienceApiModule.XCMS.csproj
+++ b/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS/VirtoCommerce.ExperienceApiModule.XCMS.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.ContentModule.Core" Version="3.800.0" />
+    <PackageReference Include="VirtoCommerce.ContentModule.Core" Version="3.802.0-alpha.940-vcst-689-content-type-filter" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\VirtoCommerce.ExperienceApiModule.Core\VirtoCommerce.ExperienceApiModule.Core.csproj" />

--- a/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS/VirtoCommerce.ExperienceApiModule.XCMS.csproj
+++ b/src/XCMS/VirtoCommerce.ExperienceApiModule.XCMS/VirtoCommerce.ExperienceApiModule.XCMS.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.ContentModule.Core" Version="3.802.0-alpha.940-vcst-689-content-type-filter" />
+    <PackageReference Include="VirtoCommerce.ContentModule.Core" Version="3.802.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\VirtoCommerce.ExperienceApiModule.Core\VirtoCommerce.ExperienceApiModule.Core.csproj" />


### PR DESCRIPTION
## Description
feat: Added Content Type filter to enable filtering by pages. It prevents from retrieving blogs via page query.

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-689
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.812.0-pr-537-6acb.zip
