### PR TITLE
VCST-541: Product StartDate and endDate for product does not work in xapi

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Index/IndexSearchRequestBuilder.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Index/IndexSearchRequestBuilder.cs
@@ -92,6 +92,37 @@ namespace VirtoCommerce.ExperienceApiModule.XDigitalCatalog.Index
             return this;
         }
 
+        public IndexSearchRequestBuilder AddCertainDateFilter(DateTime certainDate)
+        {
+            var startDateFilter = new RangeFilter
+            {
+                FieldName = "startdate",
+                Values = [new RangeFilterValue
+                    {
+                        Lower = null,
+                        Upper = certainDate.ToString("O"),
+                        IncludeLower = false,
+                        IncludeUpper = true,
+                    }]
+            };
+
+            var endDateFilter = new RangeFilter
+            {
+                FieldName = "enddate",
+                Values = [new RangeFilterValue
+                    {
+                        Lower = certainDate.ToString("O"),
+                        Upper = null,
+                        IncludeLower = false,
+                        IncludeUpper = true,
+                    }]
+            };
+
+            AddFiltersToSearchRequest([startDateFilter, endDateFilter]);
+
+            return this;
+        }
+
         public IndexSearchRequestBuilder AddObjectIds(IEnumerable<string> ids)
         {
             if (!ids.IsNullOrEmpty())

--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/SearchProductQueryHandler.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Queries/SearchProductQueryHandler.cs
@@ -117,6 +117,7 @@ namespace VirtoCommerce.XDigitalCatalog.Queries
                                             .WithUserId(request.UserId)
                                             .WithCurrency(currency.Code)
                                             .WithFuzzy(request.Fuzzy, request.FuzzyLevel)
+                                            .AddCertainDateFilter(DateTime.UtcNow)
                                             .ParseFilters(_phraseParser, request.Filter)
                                             .WithSearchPhrase(request.Query)
                                             .WithPaging(request.Skip, request.Take)


### PR DESCRIPTION
## Description
fix: Adds CertainDate Filter to for product search in xapi if First listed and Listing expires are configured for product.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-541
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.814.0-pr-538-9ac8.zip
