### PR TITLE
VCST-818: Delete Second cart after merge

### DIFF
--- a/src/XPurchase/VirtoCommerce.XPurchase/Commands/MergeCartCommand.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Commands/MergeCartCommand.cs
@@ -13,5 +13,7 @@ namespace VirtoCommerce.XPurchase.Commands
         }
 
         public string SecondCartId { get; set; }
+
+        public bool DeleteAfterMerge { get; set; } = true;
     }
 }

--- a/src/XPurchase/VirtoCommerce.XPurchase/Commands/MergeCartCommandHandler.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Commands/MergeCartCommandHandler.cs
@@ -18,8 +18,11 @@ namespace VirtoCommerce.XPurchase.Commands
             {
                 cartAggr = await cartAggr.MergeWithCartAsync(secondCart);
                 await CartRepository.SaveAsync(cartAggr);
+                if (request.DeleteAfterMerge)
+                {
+                    await CartRepository.RemoveCartAsync(secondCart.Id);
+                }
             }
-
             return cartAggr;
         }
     }

--- a/src/XPurchase/VirtoCommerce.XPurchase/Schemas/InputMergeCartType.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Schemas/InputMergeCartType.cs
@@ -6,8 +6,8 @@ namespace VirtoCommerce.XPurchase.Schemas
     {
         public InputMergeCartType()
         {
-            Field<NonNullGraphType<StringGraphType>>("secondCartId",
-                "Second cart Id");
+            Field<NonNullGraphType<StringGraphType>>("secondCartId", "Second cart Id");
+            Field<BooleanGraphType>("deleteAfterMerge", "Delete second cart after merge");
         }
     }
 }


### PR DESCRIPTION
## Description
fix: The anonymous cart is not cleared after merge. After the fix, the mutation will delete second cart after merge by default. Added mutation option deleteAfterMerge: bool. By default, true.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-818
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.815.0-pr-539-3613.zip
