### PR TITLE
VCST-881:PriceRange Aggregation is not functioning as expected.

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/VirtoCommerce.XDigitalCatalog.csproj
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/VirtoCommerce.XDigitalCatalog.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>True</IsPackable>
@@ -13,7 +13,7 @@
     <PackageReference Include="PipelineNet" Version="0.9.0" />
     <PackageReference Include="Serialize.Linq" Version="3.0.148" />
     <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.803.0" />
-    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.800.0" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.807" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.800.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.800.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.800.0" />

--- a/src/VirtoCommerce.ExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ExperienceApiModule.Web/module.manifest
@@ -6,7 +6,7 @@
   <platformVersion>3.813.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Cart" version="3.803.0" />
-    <dependency id="VirtoCommerce.Catalog" version="3.800.0" />
+    <dependency id="VirtoCommerce.Catalog" version="3.807" />
     <dependency id="VirtoCommerce.Content" version="3.802.0" />
     <dependency id="VirtoCommerce.Core" version="3.800.0" />
     <dependency id="VirtoCommerce.Customer" version="3.800.0" />


### PR DESCRIPTION
## Description
fix: Fixed the issue where the price range aggregation property was not being included in the response of the /api/catalog/search/products. Depend from catalog 3.807

## References
### QA-test:
### Jira-link:



https://virtocommerce.atlassian.net/browse/VCST-881
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.820.0-pr-543-022b.zip