### PR TITLE
VCST-661: The effect off X cart subtotal, no more than Y does not take an account the selected items in cart

### DIFF
--- a/src/XPurchase/VirtoCommerce.XPurchase/Extensions/RewardExtensions.cs
+++ b/src/XPurchase/VirtoCommerce.XPurchase/Extensions/RewardExtensions.cs
@@ -60,7 +60,7 @@ namespace VirtoCommerce.XPurchase.Extensions
                 payment.ApplyRewards(shoppingCart.Currency, paymentRewards);
             }
 
-            var subTotalExcludeDiscount = shoppingCart.Items.Sum(li => (li.ListPrice - li.DiscountAmount) * li.Quantity);
+            var subTotalExcludeDiscount = shoppingCart.Items.Where(li => li.SelectedForCheckout).Sum(li => (li.ListPrice - li.DiscountAmount) * li.Quantity);
 
             var cartRewards = rewards.OfType<CartSubtotalReward>();
             foreach (var reward in cartRewards.Where(reward => reward.IsValid))


### PR DESCRIPTION
## Description
fix: The effect off X cart subtotal, no more than Y does not take an account the selected items in cart.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-661
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.821.0-pr-544-3389.zip