### PR TITLE
VCST-1047: login-on-begalf for token auth

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.Core/VirtoCommerce.ExperienceApiModule.Core.csproj
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/VirtoCommerce.ExperienceApiModule.Core.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="RedLock.net" Version="2.3.2" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.800.0" />
     <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.800.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.813.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.819.0" />
     <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.800.0" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.800.0" />
     <PackageReference Include="VirtoCommerce.TaxModule.Core" Version="3.800.0" />

--- a/src/VirtoCommerce.ExperienceApiModule.Web/Extensions/HttpContextExtensions.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Web/Extensions/HttpContextExtensions.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using OpenIddict.Abstractions;
-using VirtoCommerce.ExperienceApiModule.Core;
 using VirtoCommerce.ExperienceApiModule.Core.Infrastructure;
 using VirtoCommerce.Platform.Core;
 using VirtoCommerce.Platform.Core.Security;
@@ -37,12 +36,6 @@ namespace VirtoCommerce.ExperienceApiModule.Web.Extensions
             }
 
             return userContext;
-        }
-
-        private static string GetCurrentUserId(ClaimsPrincipal claimsPrincipal)
-        {
-            return claimsPrincipal?.FindFirstValue(ClaimTypes.NameIdentifier)
-                ?? claimsPrincipal?.FindFirstValue("name") ?? AnonymousUser.UserName;
         }
 
         private static bool TryResolveTokenLoginOnBehalf(HttpContext context, ref ClaimsPrincipal principal, ref string operatorUserName)

--- a/src/VirtoCommerce.ExperienceApiModule.Web/Extensions/HttpContextExtensions.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Web/Extensions/HttpContextExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using OpenIddict.Abstractions;
+using VirtoCommerce.ExperienceApiModule.Core;
 using VirtoCommerce.ExperienceApiModule.Core.Infrastructure;
 using VirtoCommerce.Platform.Core;
 using VirtoCommerce.Platform.Core.Security;
@@ -12,15 +13,62 @@ namespace VirtoCommerce.ExperienceApiModule.Web.Extensions
 {
     public static class HttpContextExtensions
     {
+        public const string ImpersonatedCustomerIdClaimType = "vc_xapi_impersonated_customerid";
+
         public static GraphQLUserContext BuildGraphQLUserContext(this HttpContext context)
         {
             var principal = context.User;
             var operatorUserName = default(string);
 
             // Impersonate a user based on their VC account object id by passing that value along with the header VirtoCommerce-User-Name.
-            if (principal != null
-                && context.Request.Headers.TryGetValue("VirtoCommerce-User-Name", out var userNameFromHeader)
-                && principal.IsInRole(PlatformConstants.Security.SystemRoles.Administrator))
+            if (principal != null)
+            {
+                if (!TryResolveLegacyLoginOnBehalf(context, ref principal, ref operatorUserName))
+                {
+                    TryResolveTokenLoginOnBehalf(context, ref principal, ref operatorUserName);
+                }
+            }
+
+            var userContext = new GraphQLUserContext(principal);
+
+            if (!string.IsNullOrEmpty(operatorUserName))
+            {
+                userContext.TryAdd("OperatorUserName", operatorUserName);
+            }
+
+            return userContext;
+        }
+
+        private static string GetCurrentUserId(ClaimsPrincipal claimsPrincipal)
+        {
+            return claimsPrincipal?.FindFirstValue(ClaimTypes.NameIdentifier)
+                ?? claimsPrincipal?.FindFirstValue("name") ?? AnonymousUser.UserName;
+        }
+
+        private static bool TryResolveTokenLoginOnBehalf(HttpContext context, ref ClaimsPrincipal principal, ref string operatorUserName)
+        {
+            var impersonatedCustomerId = principal.FindFirstValue(ImpersonatedCustomerIdClaimType);
+
+            if (!string.IsNullOrEmpty(impersonatedCustomerId))
+            {
+                var factory = context.RequestServices.GetService<Func<SignInManager<ApplicationUser>>>();
+                var signInManager = factory();
+                var user = signInManager.UserManager.FindByIdAsync(impersonatedCustomerId).GetAwaiter().GetResult();
+                if (user != null)
+                {
+                    operatorUserName = context.User.Identity.Name;
+                    principal = signInManager.CreateUserPrincipalAsync(user).GetAwaiter().GetResult();
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool TryResolveLegacyLoginOnBehalf(HttpContext context, ref ClaimsPrincipal principal, ref string operatorUserName)
+        {
+            if (context.Request.Headers.TryGetValue("VirtoCommerce-User-Name", out var userNameFromHeader)
+                            && principal.IsInRole(PlatformConstants.Security.SystemRoles.Administrator))
             {
                 if (userNameFromHeader == "Anonymous")
                 {
@@ -49,16 +97,11 @@ namespace VirtoCommerce.ExperienceApiModule.Web.Extensions
                         operatorUserName = operatorUserNameHeader;
                     }
                 }
+
+                return true;
             }
 
-            var userContext = new GraphQLUserContext(principal);
-
-            if (!string.IsNullOrEmpty(operatorUserName))
-            {
-                userContext.TryAdd("OperatorUserName", operatorUserName);
-            }
-
-            return userContext;
+            return false;
         }
     }
 }

--- a/src/VirtoCommerce.ExperienceApiModule.Web/Extensions/HttpContextExtensions.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Web/Extensions/HttpContextExtensions.cs
@@ -12,7 +12,7 @@ namespace VirtoCommerce.ExperienceApiModule.Web.Extensions
 {
     public static class HttpContextExtensions
     {
-        public const string ImpersonatedCustomerIdClaimType = "vc_xapi_impersonated_customerid";
+        private const string ImpersonatedUserNameClaimType = "vc_impersonated_user_name";
 
         public static GraphQLUserContext BuildGraphQLUserContext(this HttpContext context)
         {
@@ -40,13 +40,13 @@ namespace VirtoCommerce.ExperienceApiModule.Web.Extensions
 
         private static bool TryResolveTokenLoginOnBehalf(HttpContext context, ref ClaimsPrincipal principal, ref string operatorUserName)
         {
-            var impersonatedCustomerId = principal.FindFirstValue(ImpersonatedCustomerIdClaimType);
+            var impersonatedUserName = principal.FindFirstValue(ImpersonatedUserNameClaimType);
 
-            if (!string.IsNullOrEmpty(impersonatedCustomerId))
+            if (!string.IsNullOrEmpty(impersonatedUserName))
             {
                 var factory = context.RequestServices.GetService<Func<SignInManager<ApplicationUser>>>();
                 var signInManager = factory();
-                var user = signInManager.UserManager.FindByIdAsync(impersonatedCustomerId).GetAwaiter().GetResult();
+                var user = signInManager.UserManager.FindByNameAsync(impersonatedUserName).GetAwaiter().GetResult();
                 if (user != null)
                 {
                     operatorUserName = context.User.Identity.Name;

--- a/src/VirtoCommerce.ExperienceApiModule.Web/Extensions/HttpContextExtensions.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Web/Extensions/HttpContextExtensions.cs
@@ -12,9 +12,6 @@ namespace VirtoCommerce.ExperienceApiModule.Web.Extensions
 {
     public static class HttpContextExtensions
     {
-        // TODO: Replace with PlatformConstants.Security.Claims.OperatorUserName
-        private const string OperatorUserNameClaimType = "vc_operator_name";
-
         public static GraphQLUserContext BuildGraphQLUserContext(this HttpContext context)
         {
             var principal = context.User;
@@ -41,7 +38,7 @@ namespace VirtoCommerce.ExperienceApiModule.Web.Extensions
 
         private static bool TryResolveTokenLoginOnBehalf(ClaimsPrincipal principal, ref string operatorUserName)
         {
-            operatorUserName = principal.FindFirstValue(OperatorUserNameClaimType);
+            operatorUserName = principal.FindFirstValue(PlatformConstants.Security.Claims.OperatorUserName);
 
             return !string.IsNullOrEmpty(operatorUserName);
         }

--- a/src/VirtoCommerce.ExperienceApiModule.Web/module.manifest
+++ b/src/VirtoCommerce.ExperienceApiModule.Web/module.manifest
@@ -3,7 +3,7 @@
   <id>VirtoCommerce.ExperienceApi</id>
   <version>3.822.0</version>
   <version-tag />
-  <platformVersion>3.813.0</platformVersion>
+  <platformVersion>3.819.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Cart" version="3.803.0" />
     <dependency id="VirtoCommerce.Catalog" version="3.807.0" />


### PR DESCRIPTION
## Description
feat: Adds the capability to perform login-on-behalf (impersonation) using token authentication within the XAPI framework. The new feature extends the /connect/token flow by adding support for a custom grant type called impersonate. Users can now leverage the grant_type=impersonate&user_id={user_id} parameter to set the vc_xapi_impersonated_customerid for impersonation purposes. Ensure that the account initiating the impersonation has the necessary platform:security:loginOnBehalf permission. To reset the impersonation , use the grant_type=impersonate and empty user_id.


## References
### QA-test:
### Jira-link:




https://virtocommerce.atlassian.net/browse/VCST-934
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.822.0-pr-546-5199.zip