### PR TITLE
Log POST /graphql requests per one operation (one request - one operation)

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.Core/Infrastructure/CustomGraphQLExecuter.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Infrastructure/CustomGraphQLExecuter.cs
@@ -89,16 +89,6 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Infrastructure
                 _telemetryClient.TrackException(exeptionTelemetry);
             }
 
-            //try
-            //{
-            //    // sends AppInsights telemerty 
-            //    _telemetryClient.StopOperation(operation);
-            //}
-            //catch
-            //{
-            //    // do nothing if telemerty sending fails for any reason
-            //}
-
             return result;
         }
     }

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Infrastructure/CustomGraphQLExecuter.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Infrastructure/CustomGraphQLExecuter.cs
@@ -62,7 +62,7 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Infrastructure
             requestTelemetry.Context.Operation.Name = appInsightsOperationName;
             requestTelemetry.Properties["Type"] = "GraphQL";
 
-            var operation = _telemetryClient.StartOperation(requestTelemetry);
+            using var operation = _telemetryClient.StartOperation<RequestTelemetry>(Guid.NewGuid().ToString());
 
             // execute GraphQL query
             var result = await base.ExecuteAsync(operationName, query, variables, context, requestServices, cancellationToken);
@@ -87,15 +87,15 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Infrastructure
                 _telemetryClient.TrackException(exeptionTelemetry);
             }
 
-            try
-            {
-                // sends AppInsights telemerty 
-                _telemetryClient.StopOperation(operation);
-            }
-            catch
-            {
-                // do nothing if telemerty sending fails for any reason
-            }
+            //try
+            //{
+            //    // sends AppInsights telemerty 
+            //    _telemetryClient.StopOperation(operation);
+            //}
+            //catch
+            //{
+            //    // do nothing if telemerty sending fails for any reason
+            //}
 
             return result;
         }

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Infrastructure/CustomGraphQLExecuter.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Infrastructure/CustomGraphQLExecuter.cs
@@ -55,12 +55,11 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Infrastructure
 
             var requestTelemetry = new RequestTelemetry
             {
-                //Replace   W3C Trace Context id generation  https://www.w3.org/TR/trace-context/ to unique value
-                Id = Guid.NewGuid().ToString(),
                 Name = appInsightsOperationName,
                 Url = new Uri(_httpContextAccessor.HttpContext.Request.GetEncodedUrl()),
             };
-
+            //Replace   W3C Trace Context id generation  https://www.w3.org/TR/trace-context/ to unique value
+            requestTelemetry.Context.Operation.Id = Guid.NewGuid().ToString();
             requestTelemetry.Context.Operation.Name = appInsightsOperationName;
             requestTelemetry.Properties["Type"] = "GraphQL";
 

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Infrastructure/CustomGraphQLExecuter.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Infrastructure/CustomGraphQLExecuter.cs
@@ -59,7 +59,7 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Infrastructure
                 Url = new Uri(_httpContextAccessor.HttpContext.Request.GetEncodedUrl()),
             };
             //Replace   W3C Trace Context id generation  https://www.w3.org/TR/trace-context/ to unique value
-            requestTelemetry.Context.Operation.Id = Guid.NewGuid().ToString();
+            requestTelemetry.Context.Operation.Id = Guid.NewGuid().ToString("N");
             requestTelemetry.Context.Operation.Name = appInsightsOperationName;
             requestTelemetry.Properties["Type"] = "GraphQL";
 

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Infrastructure/CustomGraphQLExecuter.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Infrastructure/CustomGraphQLExecuter.cs
@@ -55,6 +55,8 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Infrastructure
 
             var requestTelemetry = new RequestTelemetry
             {
+                //Replace   W3C Trace Context id generation  https://www.w3.org/TR/trace-context/ to unique value
+                Id = Guid.NewGuid().ToString(),
                 Name = appInsightsOperationName,
                 Url = new Uri(_httpContextAccessor.HttpContext.Request.GetEncodedUrl()),
             };
@@ -62,7 +64,7 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Infrastructure
             requestTelemetry.Context.Operation.Name = appInsightsOperationName;
             requestTelemetry.Properties["Type"] = "GraphQL";
 
-            using var operation = _telemetryClient.StartOperation<RequestTelemetry>(Guid.NewGuid().ToString());
+            using var operation = _telemetryClient.StartOperation(requestTelemetry);
 
             // execute GraphQL query
             var result = await base.ExecuteAsync(operationName, query, variables, context, requestServices, cancellationToken);


### PR DESCRIPTION
## Description
Currently AI logs all graphql request for operation id is generated a unique identifier for a span in the context of distributed tracing, following the W3C Trace Context specification https://www.w3.org/TR/trace-context/. The generated span ID helps track the execution flow across different services or components in a distributed system.  

![image](https://github.com/VirtoCommerce/vc-module-experience-api/assets/7566324/f4f9642d-125d-4cc4-a287-8068addfacd8)

After this changes each /graphql will be logged  within single operation, this will simplify logs reading process and produces correct performance requests counters


![image](https://github.com/VirtoCommerce/vc-module-experience-api/assets/7566324/8fcb9473-2e3e-4fe7-b5a8-43b4cf0e1731)

## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.823.0-pr-547-fc33.zip