### PR TITLE
VCST-1273: Add environment name to store settings

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/ModuleConstants.cs
@@ -9,6 +9,14 @@ namespace VirtoCommerce.ExperienceApiModule.Core
         {
             public static class General
             {
+                public static SettingDescriptor EnvironmentName { get; } = new()
+                {
+                    Name = "VirtoCommerce.Platform.EnvironmentName",
+                    ValueType = SettingValueType.ShortText,
+                    GroupName = "Platform|General",
+                    DefaultValue = string.Empty,
+                };
+
                 public static SettingDescriptor CreateAnonymousOrder { get; } = new SettingDescriptor
                 {
                     Name = "XOrder.CreateAnonymousOrderEnabled",
@@ -21,6 +29,7 @@ namespace VirtoCommerce.ExperienceApiModule.Core
                 {
                     get
                     {
+                        yield return EnvironmentName;
                         yield return CreateAnonymousOrder;
                     }
                 }

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Queries/StoreSettings.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Queries/StoreSettings.cs
@@ -22,6 +22,8 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Queries
 
         public string SeoLinkType { get; set; }
 
+        public string EnvironmentName { get; set; }
+
         public PasswordOptions PasswordRequirements { get; set; }
 
         public ModuleSettings[] Modules { get; set; }

--- a/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/StoreSettingsType.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Schemas/StoreSettingsType.cs
@@ -7,7 +7,7 @@ public class StoreSettingsType : ExtendableGraphType<StoreSettings>
 {
     public StoreSettingsType()
     {
-        Field(x => x.QuotesEnabled).Description("Store ID");
+        Field(x => x.QuotesEnabled).Description("Quotes enabled");
         Field(x => x.SubscriptionEnabled).Description("Store ID");
         Field(x => x.TaxCalculationEnabled).Description("Tax calculation enabled");
         Field(x => x.AnonymousUsersAllowed).Description("Allow anonymous users to visit the store ");
@@ -16,6 +16,7 @@ public class StoreSettingsType : ExtendableGraphType<StoreSettings>
         Field(x => x.EmailVerificationRequired).Description("Email address verification required");
         Field(x => x.CreateAnonymousOrderEnabled).Description("Allow anonymous users to create orders (XAPI)");
         Field(x => x.SeoLinkType).Description("SEO links");
+        Field(x => x.EnvironmentName).Description("Environment name");
         Field<PasswordOptionsType>("passwordRequirements", "Password requirements");
         Field<NonNullGraphType<ListGraphType<NonNullGraphType<ModuleSettingsType>>>>("modules");
     }

--- a/src/VirtoCommerce.ExperienceApiModule.Web/Localizations/en.VirtoCommerce.ExperienceApi.json
+++ b/src/VirtoCommerce.ExperienceApiModule.Web/Localizations/en.VirtoCommerce.ExperienceApi.json
@@ -1,5 +1,9 @@
 {
   "settings": {
+    "VirtoCommerce.Platform.EnvironmentName": {
+      "title": "Environment name",
+      "description": ""
+    },
     "XOrder.CreateAnonymousOrderEnabled": {
       "title": "Allow anonymous users to create orders (XAPI)",
       "description": "This setting is store level."


### PR DESCRIPTION
## Description
```graphql
query {
  store(storeId: "b2b-store") {
    settings {
      environmentName
    }
  }
}
```
![image](https://github.com/VirtoCommerce/vc-module-experience-api/assets/8775253/b331ad82-0db3-4533-9ce8-4446a8c5e60a)
## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-1273
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.830.0-pr-556-0d70.zip