### PR TITLE
VCST-1473: Seo info is missing on product page

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.Core/Extensions/SeoInfosExtensions.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.Core/Extensions/SeoInfosExtensions.cs
@@ -37,7 +37,7 @@ namespace VirtoCommerce.ExperienceApiModule.Core.Extensions
         private static SeoInfo GetBestMatchingSeoInfoInternal(IList<SeoInfo> seoInfos, string storeId,
             string defaultStoreLang, string cultureName, string slug, string permalink)
         {
-            if (storeId.IsNullOrEmpty() || cultureName.IsNullOrEmpty() || slug.IsNullOrEmpty())
+            if (storeId.IsNullOrEmpty() || cultureName.IsNullOrEmpty())
             {
                 return null;
             }


### PR DESCRIPTION
## Description
fix: Seo info has been missing on the product page since 3.834.0

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-1473
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.838.0-pr-562-ed8b.zip