### PR TITLE
Fixed variation binding to support the Lucene search engine when prod…

### DIFF
--- a/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Binding/VariationsBinder.cs
+++ b/src/VirtoCommerce.ExperienceApiModule.DigitalCatalog/Binding/VariationsBinder.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using VirtoCommerce.ExperienceApiModule.Core.Binding;
 using VirtoCommerce.SearchModule.Core.Model;
@@ -10,11 +11,19 @@ namespace VirtoCommerce.XDigitalCatalog.Binding
 
         public virtual object BindModel(SearchDocument searchDocument)
         {
-            var fieldName = BindingInfo.FieldName;
+            if (!searchDocument.TryGetValue(BindingInfo.FieldName, out var value))
+            {
+                return new List<string>();
+            }
 
-            return searchDocument.ContainsKey(fieldName) && searchDocument[fieldName] is object[] objs
-                ? objs.Select(x => (string)x).ToList()
-                : Enumerable.Empty<string>().ToList();
+            // It is important to note that not all search engines, such as Lucene, support field types as collections,
+            // so they may not return an array for single value
+            return value switch
+            {
+                IEnumerable<object> objs => objs.Select(x => x.ToString()).ToList(),
+                string s => [s],
+                _ => []
+            };
         }
     }
 }


### PR DESCRIPTION
Fixed variation binding to support the Lucene search engine when product has only one variation. In this case Lucene stores __variations field value as string type. 

## Description
Variation binding assumes that search engines return a list of variation IDs for a product. However, if a product has only one variation, Lucene returns a single object instead. As a result, the GraphQL query returns an empty list of variations in this case.

## References
### QA-test:
### Jira-link:

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ExperienceApi_3.845.0-pr-571-3b70.zip